### PR TITLE
Fix potential deadlock

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -26,6 +26,7 @@ import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.Label;
 import hudson.model.Node;
+import hudson.model.Queue;
 import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.slaves.Cloud;
@@ -52,6 +53,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -199,7 +201,25 @@ public class EC2FleetCloud extends Cloud
         }
     }
 
-    @Override public synchronized Collection<NodeProvisioner.PlannedNode> provision(
+    @Override public Collection<NodeProvisioner.PlannedNode> provision(
+            final Label label, final int excessWorkload) {
+        try {
+            return Queue.withLock(new Callable<Collection<NodeProvisioner.PlannedNode>>()
+            {
+                @Override
+                public Collection<NodeProvisioner.PlannedNode> call()
+                        throws Exception
+                {
+                    return provisionInternal(label, excessWorkload);
+                }
+            });
+        } catch (Exception exception) {
+            LOGGER.log(Level.WARNING, "provisionInternal failed", exception);
+            throw new IllegalStateException(exception);
+        }
+    }
+
+    public synchronized Collection<NodeProvisioner.PlannedNode> provisionInternal(
             final Label label, final int excessWorkload) {
 
 


### PR DESCRIPTION
Locks in plugin should be acquired in the same order.
IdleRetentionStrategy was acquiring Queue lock first, then
locked EC2FleetCloud instance. EC2FleetCould (through CloundNanny)
first acquired lock on itself then on Queue (when adding new node).
Modified ClouldNanny to acquire Queue lock before calling EC2FleetClould
method.

Fixes: https://github.com/jenkinsci/ec2-fleet-plugin/issues/13