### PR TITLE
Make Cloud Nanny Timer Configurable

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -21,9 +21,10 @@ import java.util.logging.Logger;
 public class CloudNanny extends PeriodicWork
 {
     private static final Logger LOGGER = Logger.getLogger(CloudNanny.class.getName());
+    private final String cloudNannyTimer;
 
     @Override public long getRecurrencePeriod() {
-        return 10000L;
+        return cloudNannyTimer;
     }
 
     @Override protected void doRun() throws Exception {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -21,7 +21,7 @@ import java.util.logging.Logger;
 public class CloudNanny extends PeriodicWork
 {
     private static final Logger LOGGER = Logger.getLogger(CloudNanny.class.getName());
-    private final String cloudNannyTimer;
+    private final long cloudNannyTimer;
 
     @Override public long getRecurrencePeriod() {
         return cloudNannyTimer;

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -54,7 +54,7 @@
     <f:description>Time in milliseconds between Spot Fleet check
     </f:description>
     <f:entry title="${%Cloud Nanny Timer}" field="cloudNannyTimer">
-      <f:textbox clazz="required" default="10000L" />
+      <f:number clazz="required" default="10000L" />
     </f:entry>
 
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="credentialsId,region,fleet" />

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -51,6 +51,11 @@
     <f:entry title="${%Maximum Cluster Size}" field="maxSize">
       <f:number clazz="required positive-number" default="1" />
     </f:entry>
+    <f:description>Time in milliseconds between Spot Fleet check
+    </f:description>
+    <f:entry title="${%Cloud Nanny Timer}" field="cloudNannyTimer">
+      <f:textbox clazz="required" default="10000L" />
+    </f:entry>
 
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="credentialsId,region,fleet" />
   </f:section>


### PR DESCRIPTION
When running a lot (20 for us) of unique Jenkins clusters with unique Spot Fleets we start running into RequestLimitExceeded error responses from Amazon. Configuring the timer to something less aggressive will help us work around this. The previous constant of 10000ms is now the default return for getRecurrencePeriod().