### PR TITLE
Change minimum for minimum cluster size from '1' to '0'

### DIFF
--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -46,7 +46,7 @@
       <f:number clazz="positive-number"/>
     </f:entry>
     <f:entry title="${%Minimum Cluster Size}" field="minSize">
-      <f:number clazz="required positive-number" default="1" />
+      <f:number clazz="required number" min="0" default="1" />
     </f:entry>
     <f:entry title="${%Maximum Cluster Size}" field="maxSize">
       <f:number clazz="required positive-number" default="1" />


### PR DESCRIPTION
The current minimum for minimum cluster size is '1'. However, there are situations where you want to set this to '0' (for example: specific instances for jobs which only occasionally run).
Amazon allows this.
We tested this change, and it works as expected.