### PR TITLE
[JENKINS-50318] - Stop caching cache objects on the disk

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,3 @@
 #!groovy
 
-buildPlugin(jenkinsVersions: [null, '2.60.1'], failFast: false)
+buildPlugin(jenkinsVersions: [null, '2.60.1', '2.107.1'], failFast: false)

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.32</version>
+    <version>3.6</version>
     <relativePath />
   </parent>
 
@@ -16,11 +16,12 @@
 
   <properties>
     <jenkins.version>1.625.3</jenkins.version>
+    <java.level>7</java.level>
   </properties>
 
   <name>EC2 Fleet Jenkins Plugin</name>
   <description>Support EC2 SpotFleet for Jenkins</description>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Amazon+EC2+Fleet+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/Amazon+EC2+Fleet+Plugin</url>
   <licenses>
     <license>
       <name>MIT License</name>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-50318

The JEP-200 regression is caused only by `plannedNodesCache`, but I believe that all cache objects need to be made transient. 

Why?

* The cached objects should be producing a big configuration file for `EC2FleetCloud`
* Persisted caches do not give consistency over restarts. `EC2FleetCloud` has no save() logic in `updateStatus()`/`addNewSlave()`/`terminateInstance` so that the caches get saved only when you save the configuration
* Once the configuration is saved, it is restored after the restart (before JEP-200) and then taken into account in all 3 methods listed above. IMHO it causes undefined behavior which may impact the EC2 Cluster

@reviewbybees @jglick @orrc 


