### PR TITLE
Use the ceiling to calculate weightedExcessWorkload

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -209,7 +209,9 @@ public class EC2FleetCloud extends Cloud
         if (stats.getNumDesired() >= maxAllowed || !"active".equals(stats.getState()))
             return Collections.emptyList();
 
-        int weightedExcessWorkload = Math.ceil((float)excessWorkload / this.numExecutors);
+        // Calculate the ceiling, without having to work with doubles from Math.ceil
+        // https://stackoverflow.com/a/21830188/877024
+        int weightedExcessWorkload = (excessWorkload - 1) / this.numExecutors + 1;
         int targetCapacity = stats.getNumDesired() + weightedExcessWorkload;
 
         if (targetCapacity > maxAllowed)

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -209,6 +209,10 @@ public class EC2FleetCloud extends Cloud
         if (stats.getNumDesired() >= maxAllowed || !"active".equals(stats.getState()))
             return Collections.emptyList();
 
+        // Ensure we don't divide by 0, below
+        if (this.numExecutors == 0)
+            return Collections.emptyList();
+
         // Calculate the ceiling, without having to work with doubles from Math.ceil
         // https://stackoverflow.com/a/21830188/877024
         int weightedExcessWorkload = (excessWorkload - 1) / this.numExecutors + 1;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -209,9 +209,7 @@ public class EC2FleetCloud extends Cloud
         if (stats.getNumDesired() >= maxAllowed || !"active".equals(stats.getState()))
             return Collections.emptyList();
 
-	// Presumably ceil() would also be correct but I think round() works best for
-	// scenarios when numExecutors is of reasonable size.
-        int weightedExcessWorkload = Math.round((float)excessWorkload / this.numExecutors);
+        int weightedExcessWorkload = Math.ceil((float)excessWorkload / this.numExecutors);
         int targetCapacity = stats.getNumDesired() + weightedExcessWorkload;
 
         if (targetCapacity > maxAllowed)

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -209,13 +209,12 @@ public class EC2FleetCloud extends Cloud
         if (stats.getNumDesired() >= maxAllowed || !"active".equals(stats.getState()))
             return Collections.emptyList();
 
-        // Ensure we don't divide by 0, below
-        if (this.numExecutors == 0)
-            return Collections.emptyList();
+        // if the planned node has 0 executors configured force it to 1 so we end up doing an unweighted check
+        final int numExecutors = this.numExecutors == 0 ? 1 : this.numExecutors;
 
         // Calculate the ceiling, without having to work with doubles from Math.ceil
         // https://stackoverflow.com/a/21830188/877024
-        int weightedExcessWorkload = (excessWorkload + this.numExecutors - 1) / this.numExecutors;
+        final int weightedExcessWorkload = (excessWorkload + numExecutors - 1) / numExecutors;
         int targetCapacity = stats.getNumDesired() + weightedExcessWorkload;
 
         if (targetCapacity > maxAllowed)

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -215,7 +215,7 @@ public class EC2FleetCloud extends Cloud
 
         // Calculate the ceiling, without having to work with doubles from Math.ceil
         // https://stackoverflow.com/a/21830188/877024
-        int weightedExcessWorkload = (excessWorkload - 1) / this.numExecutors + 1;
+        int weightedExcessWorkload = (excessWorkload + this.numExecutors - 1) / this.numExecutors;
         int targetCapacity = stats.getNumDesired() + weightedExcessWorkload;
 
         if (targetCapacity > maxAllowed)


### PR DESCRIPTION
This PR simply switches the `Math.round` call to calculating the ceiling.

The original author didn't indicate why they thought round worked best (I think I know why), but using round causes problems with 0 instances online, 1 job in the queue, and 3+ executors configured because: `round((float)1 / x)` where `x > 2` will always return 0.  We have very low usage over the weekends, which means we experience jobs timing out because a second job never enters the queue to trigger the scale up.

I believe the intention behind the current implementation is that you don't want to trigger a scale-up if there's only 1 extra job in the queue.  However, I disagree that `round` produces a correct implementation because of the above scenario.