### PR TITLE
Calculate excess workload considering booting nodes

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -20,6 +20,7 @@ import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials
 import com.google.common.util.concurrent.SettableFuture;
 import hudson.Extension;
 import hudson.model.Descriptor;
+import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.Node;
 import hudson.model.Queue;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -268,6 +268,9 @@ public class EC2FleetCloud extends Cloud
 
         int toProvision = targetCapacity - stats.getNumDesired();
 
+        if (toProvision < 1)
+            return Collections.emptyList();
+
         LOGGER.log(Level.INFO, "Provisioning nodes. Excess workload: " + Integer.toString(weightedExcessWorkload) + ", Provisioning: " + Integer.toString(toProvision));
 
         final ModifySpotFleetRequestRequest request=new ModifySpotFleetRequestRequest();

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -323,9 +323,7 @@ public class EC2FleetCloud extends Cloud
                 instancesSeenCache.remove(node.getNodeName());
             }
             Computer computer = node.toComputer();
-            if (computer != null
-                    && computer.isOnline()
-                    && instancesBootingCache.contains(node.getNodeName()))
+            if (computer != null && computer.isOnline())
                 instancesBootingCache.remove(node.getNodeName());
         }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -267,9 +267,6 @@ public class EC2FleetCloud extends Cloud
 
         int toProvision = targetCapacity - stats.getNumDesired();
 
-        if (toProvision < 1)
-            return Collections.emptyList();
-
         LOGGER.log(Level.INFO, "Provisioning nodes. Excess workload: " + Integer.toString(weightedExcessWorkload) + ", Provisioning: " + Integer.toString(toProvision));
 
         final ModifySpotFleetRequestRequest request=new ModifySpotFleetRequestRequest();


### PR DESCRIPTION
**Update:** Tested and confirmed as working

We encountered an issue where more nodes than needed were spawned in a burst.
This was due to the fact that new nodes were both known to Jenkins and the fleet, but they where still booting resulting in the fleet plugin requesting more nodes.

_Please test this fix, I currently have no opportunity to test it. 
I've had a nullpointer on instancesBootingCache before where it didn't get initialized for an unclear reason. if it starts and runs without a nullpointer it has been fixed._
