### PR TITLE
Added ability to control the cloud name

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -120,7 +120,8 @@ public class EC2FleetCloud extends Cloud {
     }
 
     @DataBoundConstructor
-    public EC2FleetCloud(final String awsCredentialsId,
+    public EC2FleetCloud(final String name,
+                         final String awsCredentialsId,
                          final @Deprecated String credentialsId,
                          final String region,
                          final String fleet,
@@ -133,7 +134,7 @@ public class EC2FleetCloud extends Cloud {
                          final Integer minSize,
                          final Integer maxSize,
                          final Integer numExecutors) {
-        super(FLEET_CLOUD_ID);
+        super(name == null || name.equals("") ? FLEET_CLOUD_ID : name);
         initCaches();
         this.credentialsId = credentialsId;
         this.awsCredentialsId = awsCredentialsId;
@@ -434,7 +435,7 @@ public class EC2FleetCloud extends Cloud {
 
         final FleetNode slave = new FleetNode(instanceId, "Fleet slave for " + instanceId,
                 fsRoot, this.numExecutors.toString(), Node.Mode.NORMAL, this.labelString, new ArrayList<NodeProperty<?>>(),
-                FLEET_CLOUD_ID, computerConnector.launch(address, TaskListener.NULL));
+                this.name, computerConnector.launch(address, TaskListener.NULL));
 
         // Initialize our retention strategy
         slave.setRetentionStrategy(new IdleRetentionStrategy(this));
@@ -494,7 +495,7 @@ public class EC2FleetCloud extends Cloud {
             final Computer c = jenkins.getNode(instanceId).toComputer();
             if (c.isOnline()) {
                 c.disconnect(SimpleOfflineCause.create(
-                        Messages._SlaveComputer_DisconnectedBy(this.FLEET_CLOUD_ID, this.fleet)));
+                        Messages._SlaveComputer_DisconnectedBy(this.name, this.fleet)));
             }
         }
         final Computer c = jenkins.getNode(instanceId).toComputer();

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -6,6 +6,9 @@
 
 
   <f:section title="${%Spot Fleet Configuration}">
+    <f:entry title="${%Name}" field="name">
+        <f:textbox default="FleetCloud"/>
+    </f:entry>
     <f:entry title="${%AWS Credentials}" field="awsCredentialsId">
       <c:select/>
     </f:entry>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
@@ -1,0 +1,3 @@
+<div>
+    Provide a name for this EC2 Fleet Cloud
+</div>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -252,9 +252,29 @@ public class EC2FleetCloudTest {
     }
 
     @Test
+    public void getDisplayName_returnDefaultWhenNull() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                null, null, null, null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
+    }
+
+    @Test
+    public void getDisplayName_returnDisplayName() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                "CloudName", null, null, null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
+    }
+
+    @Test
     public void getAwsCredentialsId_returnNull_whenNoCredentialsIdOrAwsCredentialsId() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, null, null, null,
+                null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null);
@@ -264,7 +284,7 @@ public class EC2FleetCloudTest {
     @Test
     public void getAwsCredentialsId_returnValue_whenCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, "Opa", null, null,
+                null, null, "Opa", null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null);
@@ -274,7 +294,7 @@ public class EC2FleetCloudTest {
     @Test
     public void getAwsCredentialsId_returnValue_whenAwsCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                "Opa", null, null, null,
+                null, "Opa", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null);
@@ -284,7 +304,7 @@ public class EC2FleetCloudTest {
     @Test
     public void getAwsCredentialsId_returnAwsCredentialsId_whenAwsCredentialsIdAndCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                "A", "B", null, null,
+                null, "A", "B", null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -55,7 +55,7 @@ public class IntegrationTest {
 
     @Test
     public void shouldShowInConfigurationClouds() throws IOException, SAXException {
-        Cloud cloud = new EC2FleetCloud(null, null, null, null,
+        Cloud cloud = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0);
         j.jenkins.clouds.add(cloud);
@@ -80,7 +80,7 @@ public class IntegrationTest {
         withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
             @Override
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
-                EC2FleetCloud cloud = new EC2FleetCloud("credId", null, null, fleetId,
+                EC2FleetCloud cloud = new EC2FleetCloud(null,"credId", null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0);
                 j.jenkins.clouds.add(cloud);
@@ -113,7 +113,7 @@ public class IntegrationTest {
         withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
             @Override
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
-                EC2FleetCloud cloud = new EC2FleetCloud("credId", null, null, fleetId,
+                EC2FleetCloud cloud = new EC2FleetCloud(null,"credId", null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0);
                 j.jenkins.clouds.add(cloud);


### PR DESCRIPTION
Most clouds plugins have a name property and ability to control it within the UI.
It will be nice to distinguish between cloud instances by name and by that simplify automation in an idempotent manner (replace cloud by name and type).

Kept the original behaviour, so if the cloud name is empty or null, it will be still the default name.