### PR TITLE
Scale executors by LaunchSpecification weight

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
@@ -6,12 +6,16 @@ import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesResult;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsResult;
+import com.amazonaws.services.ec2.model.SpotFleetLaunchSpecification;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -19,7 +23,8 @@ import java.util.Set;
  */
 @SuppressWarnings("unused")
 public final class FleetStateStats {
-
+    private static
+    final double DEFAULT_WEIGHT = 1.0;
     private @Nonnull
     final String fleetId;
     private @Nonnegative
@@ -31,17 +36,21 @@ public final class FleetStateStats {
     private @Nonnull
     final Set<String> instances;
     private @Nonnull
+    final Map<String, Double> instanceTypeWeights;
+    private @Nonnull
     final String label;
 
     public FleetStateStats(final @Nonnull String fleetId,
                            final int numDesired, final @Nonnull String state,
                            final @Nonnull Set<String> instances,
+                           final @Nonnull Map<String, Double> instanceTypeWeights,
                            final @Nonnull String label) {
         this.fleetId = fleetId;
         this.numActive = instances.size();
         this.numDesired = numDesired;
         this.state = state;
         this.instances = instances;
+        this.instanceTypeWeights=instanceTypeWeights;
         this.label = label;
     }
 
@@ -66,6 +75,12 @@ public final class FleetStateStats {
     @Nonnull
     public Set<String> getInstances() {
         return instances;
+    }
+
+    @Nonnull
+    public Double getInstanceTypeWeight(String instanceType)  {
+      Double instanceTypeWeight = instanceTypeWeights.get(instanceType);
+      return instanceTypeWeight == null ? DEFAULT_WEIGHT : instanceTypeWeight;
     }
 
     @Nonnull
@@ -95,10 +110,24 @@ public final class FleetStateStats {
             throw new IllegalStateException("Fleet " + fleetId + " can't be described");
 
         final SpotFleetRequestConfig fleetConfig = fleet.getSpotFleetRequestConfigs().get(0);
+        final SpotFleetRequestConfigData fleetRequestConfig = fleetConfig.getSpotFleetRequestConfig();
+
+        // Index configured instance types by weight:
+        final Map<String, Double> instanceTypeWeight = new HashMap<>();
+        for (SpotFleetLaunchSpecification launchSpecification : fleetRequestConfig.getLaunchSpecifications()) {
+            final String instanceType = launchSpecification.getInstanceType();
+            final Double instanceWeight = launchSpecification.getWeightedCapacity();
+            final Double existingWeight = instanceTypeWeight.get(instanceType);
+            if (instanceWeight == null  || (existingWeight != null && existingWeight > instanceWeight)) {
+                continue;
+            }
+            instanceTypeWeight.put(instanceType, instanceWeight);
+        }
 
         return new FleetStateStats(fleetId,
-                fleetConfig.getSpotFleetRequestConfig().getTargetCapacity(),
+                fleetRequestConfig.getTargetCapacity(),
                 fleetConfig.getSpotFleetRequestState(), instances,
+                Collections.unmodifiableMap(instanceTypeWeight),
                 label);
     }
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNode.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNode.java
@@ -17,7 +17,7 @@ public class FleetNode extends Slave implements EphemeralNode {
 
     private final String cloudName;
 
-    public FleetNode(final String name, final String nodeDescription, final String remoteFS, final String numExecutors, final Mode mode, final String label,
+    public FleetNode(final String name, final String nodeDescription, final String remoteFS, final int numExecutors, final Mode mode, final String label,
                      final List<? extends NodeProperty<?>> nodeProperties, final String cloudName, ComputerLauncher launcher) throws IOException, Descriptor.FormException {
         super(name, nodeDescription, remoteFS, numExecutors, mode, label,
                 launcher, RetentionStrategy.NOOP, nodeProperties);

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -64,6 +64,10 @@
       <f:textbox clazz="required positive-number" default="1" />
     </f:entry>
 
+    <f:entry title="${%Scale Executors by Weight}" field="scaleExecutorsByWeight">
+      <f:checkbox />
+    </f:entry>
+
     <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
       <f:number clazz="required number" min="0" default="0" />
     </f:entry>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -109,7 +109,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 null, null, null, null, false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         // when
         Collection<NodeProvisioner.PlannedNode> r = fleetCloud.provision(null, 1);
@@ -146,7 +146,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "fleetId", null, null, null, false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         // when
         FleetStateStats stats = fleetCloud.updateStatus();
@@ -207,7 +207,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         Mockito.doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -275,7 +275,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false, true);
+                false, 0, 0, 1, 1, false, true, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         Mockito.doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -498,7 +498,7 @@ public class EC2FleetCloudTest {
                 null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
     }
 
@@ -508,7 +508,7 @@ public class EC2FleetCloudTest {
                 "CloudName", null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
     }
 
@@ -518,7 +518,7 @@ public class EC2FleetCloudTest {
                 null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertNull(ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -528,7 +528,7 @@ public class EC2FleetCloudTest {
                 null, null, "Opa", null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -538,7 +538,7 @@ public class EC2FleetCloudTest {
                 null, "Opa", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -548,7 +548,7 @@ public class EC2FleetCloudTest {
                 null, "A", "B", null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -123,7 +123,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
                 "momo", null, computerConnector, false, false,
-                0, 0, 0, 1, false, false);
+                0, 0, 0, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -163,7 +163,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
                 "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, false, false);
+                0, 0, 10, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -232,7 +232,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
                 "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, false, false);
+                0, 0, 10, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -314,7 +314,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
                 "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false);
+                0, 0, 10, 1, true, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
@@ -50,7 +50,7 @@ public class RealEc2ApiIntegrationTest {
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
                 EC2FleetCloud cloud = new EC2FleetCloud("", "credId", null, null, fleetId,
                         null, null, null, false, false,
-                        0, 0, 0, 0, false, false);
+                        0, 0, 0, 0, false, false, false);
                 j.jenkins.clouds.add(cloud);
 
                 // 10 sec refresh time so wait
@@ -82,7 +82,7 @@ public class RealEc2ApiIntegrationTest {
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
                 EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, null, fleetId,
                         null, null, null, false, false,
-                        0, 0, 0, 0, false, false);
+                        0, 0, 0, 0, false, false, false);
                 j.jenkins.clouds.add(cloud);
 
                 final long start = System.currentTimeMillis();

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -44,7 +44,7 @@ public class UiIntegrationTest {
     public void shouldShowInConfigurationClouds() throws IOException, SAXException {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -57,12 +57,12 @@ public class UiIntegrationTest {
     public void shouldShowMultipleClouds() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -78,12 +78,12 @@ public class UiIntegrationTest {
     public void shouldShowMultipleCloudsWithDefaultName() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -99,12 +99,12 @@ public class UiIntegrationTest {
     public void shouldUpdateProperCloudWhenMultiple() throws IOException, SAXException {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -122,12 +122,12 @@ public class UiIntegrationTest {
     public void shouldGetFirstWhenMultipleCloudWithSameName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("FleetCloud"));
@@ -137,12 +137,12 @@ public class UiIntegrationTest {
     public void shouldGetProperWhenMultipleWithDiffName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("a"));


### PR DESCRIPTION
This is awslabs/ec2-spot-jenkins-plugin#12, rebased and cleaned up a bit for this repo.

This works nicely with a SpotFleet weighted by vCPU count (easy in the
management console).