### PR TITLE
Update node display name to include cloud name

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -377,7 +377,7 @@ public class EC2FleetCloud extends Cloud
         if (address == null)
             return; // Wait some more...
 
-        final FleetNode slave = new FleetNode(instanceId, "Fleet slave for" + instanceId,
+        final FleetNode slave = new FleetNode(instanceId, "Fleet slave for " + this.name + " (" + instanceId + ")",
                 fsRoot, this.numExecutors.toString(), Node.Mode.NORMAL, this.labelString, new ArrayList<NodeProperty<?>>(),
                 this.name, computerConnector.launch(address, TaskListener.NULL));
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -101,7 +101,8 @@ public class EC2FleetCloud extends Cloud
     }
 
     @DataBoundConstructor
-    public EC2FleetCloud(final String credentialsId,
+    public EC2FleetCloud(final String name,
+                         final String credentialsId,
                          final String region,
                          final String fleet,
                          final String labelString,
@@ -112,7 +113,7 @@ public class EC2FleetCloud extends Cloud
                          final Integer minSize,
                          final Integer maxSize,
                          final Integer numExecutors) {
-        super(FLEET_CLOUD_ID);
+        super(name == null || name.equals("") ? FLEET_CLOUD_ID : name);
         initCaches();
         this.credentialsId = credentialsId;
         this.region = region;
@@ -378,7 +379,7 @@ public class EC2FleetCloud extends Cloud
 
         final FleetNode slave = new FleetNode(instanceId, "Fleet slave for" + instanceId,
                 fsRoot, this.numExecutors.toString(), Node.Mode.NORMAL, this.labelString, new ArrayList<NodeProperty<?>>(),
-                FLEET_CLOUD_ID, computerConnector.launch(address, TaskListener.NULL));
+                this.name, computerConnector.launch(address, TaskListener.NULL));
 
         // Initialize our retention strategy
         if (getIdleMinutes() != null)

--- a/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNode.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNode.java
@@ -34,6 +34,8 @@ public class FleetNode extends Slave implements EphemeralNode
         this.cloudName = cloudName;
     }
 
+    @Override public String getDisplayName() { return cloudName + " (" + name + ")"; }
+
     @Override public Node asNode() {
         return this;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/cloud/FleetNodeComputer.java
@@ -19,6 +19,8 @@ public class FleetNodeComputer extends SlaveComputer
         return (FleetNode) super.getNode();
     }
 
+    @Override public String getDisplayName() { return getNode().getDisplayName(); }
+
     public EC2FleetCloud getCloud() {
         return getNode().getCloud();
     }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -6,6 +6,9 @@
 
 
   <f:section title="${%Spot Fleet Configuration}">
+    <f:entry title="${%Name}" field="name">
+        <f:textbox default="FleetCloud"/>
+    </f:entry>
     <f:entry title="${%AWS Crendentials}" field="credentialsId">
       <c:select/>
     </f:entry>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
@@ -1,0 +1,3 @@
+<div>
+    Provide a name for this EC2 Fleet Cloud
+</div>


### PR DESCRIPTION
This builds upon #30 and tries to partially address #10.

With this, nodes are displayed with the cloud name followed by the instance ID in parentheses. This provides slightly more information and helps distinguish nodes when you have multiple EC2 Fleets in use.