### PR TITLE
Connect at node launch.  Do not reconnect when offline.

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -2,11 +2,8 @@ package com.amazon.jenkins.ec2fleet;
 
 import hudson.model.Computer;
 import hudson.model.Node;
-import hudson.slaves.Messages;
-import hudson.slaves.OfflineCause.SimpleOfflineCause;
 import hudson.slaves.RetentionStrategy;
 import hudson.slaves.SlaveComputer;
-import java.lang.InterruptedException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,24 +42,18 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
             c.setAcceptingTasks(false);
             try {
                 if (isIdleForTooLong(c)) {
-                    // node no longer eligible for tasks after idle timeout
-                    shouldAcceptTasks = false;
                     // Find instance ID
                     Node compNode = c.getNode();
                     if (compNode == null) {
                         return 0;
                     }
+
                     final String nodeId = compNode.getNodeName();
-                    // disconnect and then terminate
-                    if (c.isOnline()) {
-                        c.disconnect(SimpleOfflineCause.create(
-                            Messages._RetentionStrategy_Demand_OfflineIdle()));
-                        c.waitUntilOffline();
+                    if (parent.terminateInstance(nodeId)) {
+                        // Instance successfully terminated, so no longer accept tasks
+                        shouldAcceptTasks = false;
                     }
-                    parent.terminateInstance(nodeId);
                 }
-            } catch (InterruptedException e) {
-                LOGGER.log(Level.WARNING, "Interrupted while diconnecting " + c.getDisplayName());
             } finally {
                 c.setAcceptingTasks(shouldAcceptTasks);
             }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -53,9 +53,6 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
                         // Instance successfully terminated, so no longer accept tasks
                         shouldAcceptTasks = false;
                     }
-                } else {
-                    if (c.isOffline() && !c.isConnecting() && c.isLaunchSupported())
-                        c.tryReconnect();
                 }
             } finally {
                 c.setAcceptingTasks(shouldAcceptTasks);
@@ -63,5 +60,10 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
         }
 
         return 1;
+    }
+
+    @Override public void start(SlaveComputer c) {
+        LOGGER.log(Level.INFO, "Connecting to instance: " + c.getDisplayName());
+        c.connect(false);
     }
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -29,7 +29,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
         long age = System.currentTimeMillis()-c.getIdleStartMilliseconds();
         long maxAge = maxIdleMinutes*60*1000;
         LOGGER.log(Level.FINE, "Instance: " + c.getDisplayName() + " Age: " + age + " Max Age:" + maxAge);
-        return System.currentTimeMillis()-c.getIdleStartMilliseconds() > (maxIdleMinutes*60*1000);
+        return age > maxAge;
     }
 
     @Override public long check(final SlaveComputer c) {


### PR DESCRIPTION
The IdleRetentionStrategy has been modified to connect to new spot fleet instance nodes when they are first launched, and to no longer use `tryReconnect()` if the node is offline.

Commentary:  When setting the "Max Idle Minutes Before Scaledown," the retention strategy changes from NoOp to the custom IdleRetentionStrategy.  I think it makes sense for that change to layer on the removal of idle nodes that have exceeded the max idle minutes.  Before this PR, the change not only layered on the removal of idle nodes, but also switched to something closer to the Always retention strategy.  This PR sets the IdleRetentionStrategy back to being like the the NoOp strategy with removal of idle nodes.
Always: https://github.com/jenkinsci/jenkins/blob/0ffb87cbbb43f8ba3498467471d1746e3fb5b749/core/src/main/java/hudson/slaves/RetentionStrategy.java#L151
NoOp: https://github.com/jenkinsci/jenkins/blob/0ffb87cbbb43f8ba3498467471d1746e3fb5b749/core/src/main/java/hudson/slaves/RetentionStrategy.java#L122

This PR addresses issue #41 