### PR TITLE
Always reconnect option

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -432,8 +432,7 @@ public class EC2FleetCloud extends Cloud
                 FLEET_CLOUD_ID, computerConnector.launch(address, TaskListener.NULL));
 
         // Initialize our retention strategy
-        if (getIdleMinutes() != null)
-            slave.setRetentionStrategy(new IdleRetentionStrategy(this));
+        slave.setRetentionStrategy(new IdleRetentionStrategy(this));
 
         final Jenkins jenkins=Jenkins.getInstance();
         //noinspection SynchronizationOnLocalVariableOrMethodParameter

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -76,6 +76,7 @@ public class EC2FleetCloud extends Cloud
     private final String fsRoot;
     private final ComputerConnector computerConnector;
     private final boolean privateIpUsed;
+    private final boolean alwaysReconnect;
     private final String labelString;
     private final Integer idleMinutes;
     private final Integer minSize;
@@ -112,6 +113,7 @@ public class EC2FleetCloud extends Cloud
                          final String fsRoot,
                          final ComputerConnector computerConnector,
                          final boolean privateIpUsed,
+                         final boolean alwaysReconnect,
                          final Integer idleMinutes,
                          final Integer minSize,
                          final Integer maxSize,
@@ -126,6 +128,7 @@ public class EC2FleetCloud extends Cloud
         this.labelString = labelString;
         this.idleMinutes = idleMinutes;
         this.privateIpUsed = privateIpUsed;
+        this.alwaysReconnect = alwaysReconnect;
         this.minSize = minSize;
         this.maxSize = maxSize;
         this.numExecutors = numExecutors;
@@ -165,6 +168,10 @@ public class EC2FleetCloud extends Cloud
 
     public boolean isPrivateIpUsed() {
         return privateIpUsed;
+    }
+
+    public boolean isAlwaysReconnectSet() {
+        return alwaysReconnect;
     }
 
     public String getLabelString(){
@@ -529,6 +536,7 @@ public class EC2FleetCloud extends Cloud
         public String fleet;
         public String userName="root";
         public boolean privateIpUsed;
+        public boolean alwaysReconnect;
         public String privateKey;
 
         public DescriptorImpl() {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -433,7 +433,7 @@ public class EC2FleetCloud extends Cloud
 
         // Initialize our retention strategy
         if (getIdleMinutes() != null)
-            slave.setRetentionStrategy(new IdleRetentionStrategy(getIdleMinutes(), this));
+            slave.setRetentionStrategy(new IdleRetentionStrategy(this));
 
         final Jenkins jenkins=Jenkins.getInstance();
         //noinspection SynchronizationOnLocalVariableOrMethodParameter

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -178,8 +178,8 @@ public class EC2FleetCloud extends Cloud
         return this.labelString;
     }
 
-    public Integer getIdleMinutes() {
-        return idleMinutes;
+    public int getIdleMinutes() {
+        return (idleMinutes != null) ? idleMinutes : 0;
     }
 
     public Integer getMaxSize() {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -170,7 +170,7 @@ public class EC2FleetCloud extends Cloud
         return privateIpUsed;
     }
 
-    public boolean isAlwaysReconnectSet() {
+    public boolean isAlwaysReconnect() {
         return alwaysReconnect;
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -45,6 +45,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
             // Ensure nobody provisions onto this node until we've done
             // checking
             boolean shouldAcceptTasks = c.isAcceptingTasks();
+            boolean justTerminated = false;
             c.setAcceptingTasks(false);
             try {
                 if (isIdleForTooLong(c)) {
@@ -58,8 +59,11 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
                     if (parent.terminateInstance(nodeId)) {
                         // Instance successfully terminated, so no longer accept tasks
                         shouldAcceptTasks = false;
+                        justTerminated = true;
                     }
-                } else if (alwaysReconnect && c.isOffline() && !c.isConnecting() && c.isLaunchSupported()) {
+                }
+
+                if (alwaysReconnect && !justTerminated && c.isOffline() && !c.isConnecting() && c.isLaunchSupported()) {
                     LOGGER.log(Level.INFO, "Reconnecting to instance: " + c.getDisplayName());
                     c.tryReconnect();
                 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -19,8 +19,8 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
 
     private static final Logger LOGGER = Logger.getLogger(IdleRetentionStrategy.class.getName());
 
-    public IdleRetentionStrategy(final int maxIdleMinutes, final EC2FleetCloud parent) {
-        this.maxIdleMinutes = maxIdleMinutes;
+    public IdleRetentionStrategy(final EC2FleetCloud parent) {
+        this.maxIdleMinutes = parent.getIdleMinutes();
         this.parent = parent;
         LOGGER.log(Level.INFO, "Idle Retention initiated");
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -29,7 +29,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
 
     protected boolean isIdleForTooLong(final Computer c) {
         boolean isTooLong = false;
-        if(maxIdleMinutes != null) {
+        if(maxIdleMinutes > 0) {
             long age = System.currentTimeMillis()-c.getIdleStartMilliseconds();
             long maxAge = maxIdleMinutes*60*1000;
             LOGGER.log(Level.FINE, "Instance: " + c.getDisplayName() + " Age: " + age + " Max Age:" + maxAge);

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -22,7 +22,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
 
     public IdleRetentionStrategy(final EC2FleetCloud parent) {
         this.maxIdleMinutes = parent.getIdleMinutes();
-        this.alwaysReconnect = parent.isAlwaysReconnectSet();
+        this.alwaysReconnect = parent.isAlwaysReconnect();
         this.parent = parent;
         LOGGER.log(Level.INFO, "Idle Retention initiated");
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -26,10 +26,14 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer>
     }
 
     protected boolean isIdleForTooLong(final Computer c) {
-        long age = System.currentTimeMillis()-c.getIdleStartMilliseconds();
-        long maxAge = maxIdleMinutes*60*1000;
-        LOGGER.log(Level.FINE, "Instance: " + c.getDisplayName() + " Age: " + age + " Max Age:" + maxAge);
-        return age > maxAge;
+        boolean isTooLong = false;
+        if(maxIdleMinutes != null) {
+            long age = System.currentTimeMillis()-c.getIdleStartMilliseconds();
+            long maxAge = maxIdleMinutes*60*1000;
+            LOGGER.log(Level.FINE, "Instance: " + c.getDisplayName() + " Age: " + age + " Max Age:" + maxAge);
+            isTooLong = age > maxAge;
+        }
+        return isTooLong;
     }
 
     @Override public long check(final SlaveComputer c) {

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -47,8 +47,10 @@
     <f:entry title="${%Number of Executors}" field="numExecutors">
       <f:textbox clazz="required positive-number" default="1" />
     </f:entry>
+    <f:description>0 for no scaledown
+    </f:description>
     <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
-      <f:number clazz="positive-number"/>
+      <f:number clazz="required number" min="0" default="0" />
     </f:entry>
     <f:entry title="${%Minimum Cluster Size}" field="minSize">
       <f:number clazz="required number" min="0" default="1" />

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -47,8 +47,6 @@
     <f:entry title="${%Number of Executors}" field="numExecutors">
       <f:textbox clazz="required positive-number" default="1" />
     </f:entry>
-    <f:description>0 for no scaledown
-    </f:description>
     <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
       <f:number clazz="required number" min="0" default="0" />
     </f:entry>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -27,6 +27,11 @@
     <f:entry title="${%Connect Private}" field="privateIpUsed">
       <f:checkbox />
     </f:entry>
+    <f:description>Always reconnect to offline nodes
+    </f:description>
+    <f:entry title="${%Always Reconnect}" field="alwaysReconnect">
+      <f:checkbox />
+    </f:entry>
     <f:description>Labels to add to instances in this fleet
     </f:description>
     <f:entry title="${%Label}" field="labelString">

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-idleMinutes.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-idleMinutes.html
@@ -1,0 +1,1 @@
+0 for no scaledown


### PR DESCRIPTION
Added a plugin configuration option named `Always Reconnect`.

When selected, Jenkins will try to reconnect any offline EC2 Fleet Node during each IdleRetentionStrategy check.

Additional Changes:

- The `Max Idle Minutes Before Scaledown` option is now required with 0 as an acceptable value.  There is a help tip for that states "0 for no scaledown" 
- Every EC2 Fleet Node will now have an IdleRetentionStrategy, even if idleMinutes is set to 0 (or null for legacy configurations).

This addresses several concerns raised in #41 after the release of version 1.1.8 which included #42  