### PR TITLE
#21 Don't show non active fleets by default in configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,29 @@
       <artifactId>jackson2-api</artifactId>
       <version>2.7.3</version>
     </dependency>
+
+    <!-- tests -->
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.2</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.objenesis</groupId>
+          <artifactId>objenesis</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -14,38 +14,37 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * User: cyberax
- * Date: 1/11/16
- * Time: 13:21
+ * @see EC2FleetCloud
  */
 @Extension
 @SuppressWarnings("unused")
-public class CloudNanny extends PeriodicWork
-{
+public class CloudNanny extends PeriodicWork {
+
     private static final Logger LOGGER = Logger.getLogger(CloudNanny.class.getName());
 
-    @Override public long getRecurrencePeriod() {
+    @Override
+    public long getRecurrencePeriod() {
         return 10000L;
     }
 
-    @Override protected void doRun() throws Exception {
+    @Override
+    protected void doRun() throws Exception {
 
         // Trigger reprovisioning as well
         Jenkins.getActiveInstance().unlabeledNodeProvisioner.suggestReviewNow();
 
         final List<FleetStateStats> stats = new ArrayList<FleetStateStats>();
-        for(final Cloud cloud : Jenkins.getActiveInstance().clouds) {
+        for (final Cloud cloud : Jenkins.getActiveInstance().clouds) {
             if (!(cloud instanceof EC2FleetCloud))
                 continue;
 
             // Update the cluster states
-            final EC2FleetCloud fleetCloud =(EC2FleetCloud) cloud;
-            LOGGER.log(Level.FINE, "Checking cloud: " + fleetCloud.getLabelString() );
+            final EC2FleetCloud fleetCloud = (EC2FleetCloud) cloud;
+            LOGGER.log(Level.FINE, "Checking cloud: " + fleetCloud.getLabelString());
             stats.add(Queue.withLock(new Callable<FleetStateStats>() {
                 @Override
                 public FleetStateStats call()
-                        throws Exception
-                {
+                        throws Exception {
                     return fleetCloud.updateStatus();
                 }
             }));
@@ -55,7 +54,7 @@ public class CloudNanny extends PeriodicWork
             if (!(w instanceof FleetStatusWidget))
                 continue;
 
-            ((FleetStatusWidget)w).setStatusList(stats);
+            ((FleetStatusWidget) w).setStatusList(stats);
         }
     }
 }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -17,7 +17,10 @@
     <f:description>Fleet list will be available once the connection is validated
     </f:description>
     <f:entry title="${%Spot Fleet}" field="fleet">
-      <f:select/>
+        <f:select/>
+    </f:entry>
+    <f:entry title="${%Show non active fleets}" field="showNonActiveSpotFleets">
+        <f:checkbox />
     </f:entry>
     <f:entry title="${%Launcher}" field="laucnher">
       <f:dropdownDescriptorSelector field="computerConnector" descriptors="${descriptor.getComputerConnectorDescriptors()}"/>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-fleet.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-fleet.html
@@ -1,0 +1,5 @@
+Select fleet which will be used to launch Jenkins workers.
+<p>
+    By default this list include only active
+fleets. If you need to see all fleet include cancelled etc. click checkbox below.
+Selected fleet will be in list regardless of fleet state.

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -232,7 +232,7 @@ public class EC2FleetCloudTest {
                 false, "", "", "failed_selected");
 
         Assert.assertEquals("a", r.get(0).value);
-        Assert.assertEquals("b", r.get(1).value);
+        Assert.assertEquals("failed_selected", r.get(1).value);
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -1,0 +1,254 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.BatchState;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsResult;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, AmazonEC2Client.class, EC2FleetCloud.class, EC2FleetCloud.DescriptorImpl.class})
+public class EC2FleetCloudTest {
+
+    private SpotFleetRequestConfig spotFleetRequestConfig1;
+    private SpotFleetRequestConfig spotFleetRequestConfig2;
+    private SpotFleetRequestConfig spotFleetRequestConfig3;
+    private SpotFleetRequestConfig spotFleetRequestConfig4;
+    private SpotFleetRequestConfig spotFleetRequestConfig5;
+    private SpotFleetRequestConfig spotFleetRequestConfig6;
+    private SpotFleetRequestConfig spotFleetRequestConfig7;
+
+    @Before
+    public void before() {
+        spotFleetRequestConfig1 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig1.setSpotFleetRequestState(BatchState.Active);
+        spotFleetRequestConfig2 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig2.setSpotFleetRequestState(BatchState.Submitted);
+        spotFleetRequestConfig3 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig3.setSpotFleetRequestState(BatchState.Modifying);
+        spotFleetRequestConfig4 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig4.setSpotFleetRequestState(BatchState.Cancelled);
+        spotFleetRequestConfig5 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig5.setSpotFleetRequestState(BatchState.Cancelled_running);
+        spotFleetRequestConfig6 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig6.setSpotFleetRequestState(BatchState.Cancelled_terminating);
+        spotFleetRequestConfig7 = new SpotFleetRequestConfig();
+        spotFleetRequestConfig7.setSpotFleetRequestState(BatchState.Failed);
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoFleetInAccount() {
+        PowerMockito.mockStatic(Jenkins.class);
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals(0, r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoActiveFleets() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig4, spotFleetRequestConfig5,
+                        spotFleetRequestConfig6, spotFleetRequestConfig7));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals(0, r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnActiveFleets() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig1, spotFleetRequestConfig2,
+                        spotFleetRequestConfig3, spotFleetRequestConfig4, spotFleetRequestConfig5,
+                        spotFleetRequestConfig6, spotFleetRequestConfig7));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals(3, r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnAllFleetsIfShowNonActiveIsEnabled() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig1, spotFleetRequestConfig2,
+                        spotFleetRequestConfig3, spotFleetRequestConfig4, spotFleetRequestConfig5,
+                        spotFleetRequestConfig6, spotFleetRequestConfig7));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                true, "", "", "");
+
+        Assert.assertEquals(7, r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnFleetInfo() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        spotFleetRequestConfig1.setSpotFleetRequestId("fleet-id");
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig1));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals("fleet-id (active)", r.get(0).name);
+        Assert.assertEquals("fleet-id", r.get(0).value);
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnFleetsCrossPages() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        when(describeSpotFleetRequestsResult.getNextToken())
+                .thenReturn("a")
+                .thenReturn("b")
+                .thenReturn(null);
+
+        spotFleetRequestConfig1.setSpotFleetRequestId("a");
+        spotFleetRequestConfig2.setSpotFleetRequestId("b");
+        spotFleetRequestConfig3.setSpotFleetRequestId("c");
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig1))
+                .thenReturn(Arrays.asList(spotFleetRequestConfig2))
+                .thenReturn(Arrays.asList(spotFleetRequestConfig3));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals("a", r.get(0).value);
+        Assert.assertEquals("b", r.get(1).value);
+        Assert.assertEquals("c", r.get(2).value);
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnSelectedFleetInAnyState() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
+        when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+
+        spotFleetRequestConfig1.setSpotFleetRequestId("a");
+        spotFleetRequestConfig2.setSpotFleetRequestId("failed_selected");
+        spotFleetRequestConfig2.setSpotFleetRequestState(BatchState.Failed);
+
+        when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
+                .thenReturn(Arrays.asList(spotFleetRequestConfig1, spotFleetRequestConfig2));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "failed_selected");
+
+        Assert.assertEquals("a", r.get(0).value);
+        Assert.assertEquals("b", r.get(1).value);
+    }
+
+    @Test
+    public void descriptorImpl_doFillFleetItems_returnEmptyListIfAnyException() throws Exception {
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.mockStatic(AmazonEC2Client.class);
+
+        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenThrow(new IllegalArgumentException("test"));
+
+        Jenkins jenkins = mock(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
+                false, "", "", "");
+
+        Assert.assertEquals(0, r.size());
+    }
+
+}


### PR DESCRIPTION
For #21 

- Don't show non active (active are only ```submitted```, ```active```, ```modification```) fleets by default on configuration page
- Add checkbox to show all fleets
- Always include selected fleet in result even if non active


![show-non-active-fleets](https://user-images.githubusercontent.com/473022/57598577-9c101a80-7508-11e9-89d7-7935f8c81d09.png)
