### PR TITLE
#15 Fix test connections (avoid conflict credentialsId with ssh creds)

### DIFF
--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -6,7 +6,7 @@
 
 
   <f:section title="${%Spot Fleet Configuration}">
-    <f:entry title="${%AWS Crendentials}" field="credentialsId">
+    <f:entry title="${%AWS Credentials}" field="awsCredentialsId">
       <c:select/>
     </f:entry>
     <f:description>The regions will be populated once the keys above are entered.
@@ -60,7 +60,7 @@
       <f:number clazz="required positive-number" default="1" />
     </f:entry>
 
-    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="credentialsId,region,fleet" />
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="awsCredentialsId,region,fleet" />
   </f:section>
 
 </j:jelly>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -251,4 +251,44 @@ public class EC2FleetCloudTest {
         Assert.assertEquals(0, r.size());
     }
 
+    @Test
+    public void getAwsCredentialsId_returnNull_whenNoCredentialsIdOrAwsCredentialsId() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                null, null, null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertNull(ec2FleetCloud.getAwsCredentialsId());
+    }
+
+    @Test
+    public void getAwsCredentialsId_returnValue_whenCredentialsIdPresent() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                null, "Opa", null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
+    }
+
+    @Test
+    public void getAwsCredentialsId_returnValue_whenAwsCredentialsIdPresent() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                "Opa", null, null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
+    }
+
+    @Test
+    public void getAwsCredentialsId_returnAwsCredentialsId_whenAwsCredentialsIdAndCredentialsIdPresent() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                "A", "B", null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null);
+        Assert.assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
+    }
+
 }


### PR DESCRIPTION
### Why?

```EC2FleetCloud``` is using field ```credentialsId``` which conflicts on Jenkins UI with similar field from ```computerConnector``` as result Jenkins pass to server side for ```test connection``` or other operations value from incorrect ```credentialsId```

### Fix

As we cannot rename var from ```computerConnector``` rename our from ```credentialsId``` to ```awsCredentialsId``` but keep both for back compatibility.