### PR TITLE
#60 check if instances terminated in batch

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -29,11 +29,10 @@ public class CloudNanny extends PeriodicWork {
 
     @Override
     protected void doRun() throws Exception {
-
         // Trigger reprovisioning as well
         Jenkins.getActiveInstance().unlabeledNodeProvisioner.suggestReviewNow();
 
-        final List<FleetStateStats> stats = new ArrayList<FleetStateStats>();
+        final List<FleetStateStats> stats = new ArrayList<>();
         for (final Cloud cloud : Jenkins.getActiveInstance().clouds) {
             if (!(cloud instanceof EC2FleetCloud))
                 continue;
@@ -43,8 +42,7 @@ public class CloudNanny extends PeriodicWork {
             LOGGER.log(Level.FINE, "Checking cloud: " + fleetCloud.getLabelString());
             stats.add(Queue.withLock(new Callable<FleetStateStats>() {
                 @Override
-                public FleetStateStats call()
-                        throws Exception {
+                public FleetStateStats call() {
                     return fleetCloud.updateStatus();
                 }
             }));

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNanny.java
@@ -51,10 +51,7 @@ public class CloudNanny extends PeriodicWork {
         }
 
         for (final Widget w : Jenkins.getInstance().getWidgets()) {
-            if (!(w instanceof FleetStatusWidget))
-                continue;
-
-            ((FleetStatusWidget) w).setStatusList(stats);
+            if (w instanceof FleetStatusWidget) ((FleetStatusWidget) w).setStatusList(stats);
         }
     }
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -1,0 +1,109 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceStateName;
+import com.amazonaws.services.ec2.model.Reservation;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@SuppressWarnings("WeakerAccess")
+public class EC2Api {
+
+    private static final ImmutableSet<String> TERMINATED_STATES = ImmutableSet.of(
+            InstanceStateName.Terminated.toString(),
+            InstanceStateName.Stopped.toString(),
+            InstanceStateName.Stopping.toString(),
+            InstanceStateName.ShuttingDown.toString()
+    );
+
+    private static final int BATCH_SIZE = 900;
+
+    private static final String NOT_FOUND_ERROR_CODE = "InvalidInstanceID.NotFound";
+    private static final Pattern INSTANCE_ID_PATTERN = Pattern.compile("(i-[0-9a-zA-Z]+)");
+
+    private static List<String> parseInstanceIdsFromNotFoundException(final String errorMessage) {
+        final Matcher fullMessageMatcher = INSTANCE_ID_PATTERN.matcher(errorMessage);
+
+        final List<String> instanceIds = new ArrayList<>();
+        while (fullMessageMatcher.find()) {
+            instanceIds.add(fullMessageMatcher.group(1));
+        }
+
+        return instanceIds;
+    }
+
+    public static Set<String> describeTerminated(final AmazonEC2 ec2, final Set<String> instanceIds) {
+        return describeTerminated(ec2, instanceIds, BATCH_SIZE);
+    }
+
+    public static Set<String> describeTerminated(final AmazonEC2 ec2, final Set<String> instanceIds, final int batchSize) {
+        // assume all terminated until we get opposite info
+        final Set<String> terminated = new HashSet<>(instanceIds);
+        // don't do actual call if no data
+        if (instanceIds.isEmpty()) return terminated;
+
+        final List<List<String>> batches = Lists.partition(new ArrayList<>(instanceIds), batchSize);
+        for (final List<String> batch : batches) {
+            describeTerminatedBatch(ec2, terminated, batch);
+        }
+        return terminated;
+    }
+
+    private static void describeTerminatedBatch(final AmazonEC2 ec2, final Set<String> terminated, final List<String> batch) {
+        // we are going to modify list, so copy
+        final List<String> copy = new ArrayList<>(batch);
+
+        // just to simplify debug by having consist order
+        Collections.sort(copy);
+
+        // because instances could be terminated at any time we do multiple
+        // retry to get status and all time remove from request all non found instances if any
+        while (copy.size() > 0) {
+            try {
+                final DescribeInstancesRequest request = new DescribeInstancesRequest().withInstanceIds(copy);
+
+                DescribeInstancesResult result;
+                do {
+                    result = ec2.describeInstances(request);
+                    request.setNextToken(result.getNextToken());
+
+                    for (final Reservation r : result.getReservations()) {
+                        for (final Instance instance : r.getInstances()) {
+                            // if instance not in terminated state, remove it from terminated
+                            if (!TERMINATED_STATES.contains(instance.getState().getName())) {
+                                terminated.remove(instance.getInstanceId());
+                            }
+                        }
+                    }
+                } while (result.getNextToken() != null);
+
+                // all good, clear request batch to stop
+                copy.clear();
+            } catch (final AmazonEC2Exception exception) {
+                // if we cannot find instance, that's fine assume them as terminated
+                // remove from request and try again
+                if (exception.getErrorCode().equals(NOT_FOUND_ERROR_CODE)) {
+                    final List<String> notFoundInstanceIds = parseInstanceIdsFromNotFoundException(exception.getMessage());
+                    if (notFoundInstanceIds.isEmpty()) {
+                        // looks like we cannot parse correctly, rethrow
+                        throw exception;
+                    }
+                    copy.removeAll(notFoundInstanceIds);
+                }
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -1,0 +1,302 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceState;
+import com.amazonaws.services.ec2.model.InstanceStateName;
+import com.amazonaws.services.ec2.model.Reservation;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EC2ApiTest {
+
+    @Mock
+    private AmazonEC2 amazonEC2;
+
+    @Test
+    public void shouldReturnEmptyResultAndNoCallIfEmptyListOfInstances() {
+        Set<String> terminated = EC2Api.describeTerminated(amazonEC2, Collections.<String>emptySet());
+
+        Assert.assertEquals(Collections.emptySet(), terminated);
+        verifyZeroInteractions(amazonEC2);
+    }
+
+    @Test
+    public void shouldReturnEmptyIfAllInstancesStillActive() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i-1");
+        instanceIds.add("i-2");
+
+        DescribeInstancesResult describeInstancesResult = new DescribeInstancesResult();
+        Reservation reservation = new Reservation();
+        Instance instance1 = new Instance()
+                .withInstanceId("i-1")
+                .withState(new InstanceState().withName(InstanceStateName.Running));
+        Instance instance2 = new Instance()
+                .withInstanceId("i-2")
+                .withState(new InstanceState().withName(InstanceStateName.Running));
+        reservation.setInstances(Arrays.asList(instance1, instance2));
+        describeInstancesResult.setReservations(Arrays.asList(reservation));
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class))).thenReturn(describeInstancesResult);
+
+        // when
+        Set<String> terminated = EC2Api.describeTerminated(amazonEC2, instanceIds);
+
+        // then
+        Assert.assertEquals(Collections.emptySet(), terminated);
+        verify(amazonEC2, times(1))
+                .describeInstances(any(DescribeInstancesRequest.class));
+    }
+
+    @Test
+    public void shouldProcessAllPagesUntilNextTokenIsAvailable() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i-1");
+        instanceIds.add("i-2");
+        instanceIds.add("i-3");
+
+        DescribeInstancesResult describeInstancesResult1 =
+                new DescribeInstancesResult()
+                        .withReservations(
+                                new Reservation().withInstances(new Instance()
+                                        .withInstanceId("i-1")
+                                        .withState(new InstanceState().withName(InstanceStateName.Running))))
+                        .withNextToken("a");
+
+        DescribeInstancesResult describeInstancesResult2 =
+                new DescribeInstancesResult()
+                        .withReservations(new Reservation().withInstances(
+                                new Instance()
+                                        .withInstanceId("i-2")
+                                        .withState(new InstanceState().withName(InstanceStateName.Running)),
+                                new Instance()
+                                        .withInstanceId("i-3")
+                                        .withState(new InstanceState().withName(InstanceStateName.Terminated))
+                        ));
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenReturn(describeInstancesResult1)
+                .thenReturn(describeInstancesResult2);
+
+        // when
+        Set<String> terminated = EC2Api.describeTerminated(amazonEC2, instanceIds);
+
+        // then
+        Assert.assertEquals(new HashSet<>(Arrays.asList("i-3")), terminated);
+        verify(amazonEC2, times(2))
+                .describeInstances(any(DescribeInstancesRequest.class));
+    }
+
+    @Test
+    public void shouldAssumeMissedInResultInstanceOrTerminatedOrStoppedOrStoppingOrShuttingDownAsTermianted() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("missed");
+        instanceIds.add("stopped");
+        instanceIds.add("terminated");
+        instanceIds.add("stopping");
+        instanceIds.add("shutting-down");
+
+        DescribeInstancesResult describeInstancesResult1 =
+                new DescribeInstancesResult()
+                        .withReservations(
+                                new Reservation().withInstances(new Instance()
+                                                .withInstanceId("stopped")
+                                                .withState(new InstanceState().withName(InstanceStateName.Stopped)),
+                                        new Instance()
+                                                .withInstanceId("stopping")
+                                                .withState(new InstanceState().withName(InstanceStateName.Stopping)),
+                                        new Instance()
+                                                .withInstanceId("shutting-down")
+                                                .withState(new InstanceState().withName(InstanceStateName.ShuttingDown)),
+                                        new Instance()
+                                                .withInstanceId("terminated")
+                                                .withState(new InstanceState().withName(InstanceStateName.Terminated))
+                                ));
+
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenReturn(describeInstancesResult1);
+
+        // when
+        Set<String> terminated = EC2Api.describeTerminated(amazonEC2, instanceIds);
+
+        // then
+        Assert.assertEquals(new HashSet<>(Arrays.asList(
+                "missed", "terminated", "stopped", "shutting-down", "stopping")), terminated);
+        verify(amazonEC2, times(1))
+                .describeInstances(any(DescribeInstancesRequest.class));
+    }
+
+    @Test
+    public void shouldSendInOneCallNoMoreThenBatchSizeOfInstance() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i1");
+        instanceIds.add("i2");
+        instanceIds.add("i3");
+
+        DescribeInstancesResult describeInstancesResult1 =
+                new DescribeInstancesResult()
+                        .withReservations(
+                                new Reservation().withInstances(new Instance()
+                                                .withInstanceId("stopped")
+                                                .withState(new InstanceState().withName(InstanceStateName.Running)),
+                                        new Instance()
+                                                .withInstanceId("stopping")
+                                                .withState(new InstanceState().withName(InstanceStateName.Running))
+                                ));
+
+        DescribeInstancesResult describeInstancesResult2 = new DescribeInstancesResult();
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenReturn(describeInstancesResult1)
+                .thenReturn(describeInstancesResult2);
+
+        // when
+        EC2Api.describeTerminated(amazonEC2, instanceIds, 2);
+
+        // then
+        verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i1", "i2")));
+        verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i3")));
+        verifyNoMoreInteractions(amazonEC2);
+    }
+
+    /**
+     * NotFound exception example data
+     * <p>
+     * <code>
+     * Single instance
+     * requestId = "0fd56c54-e11a-4928-843c-9a80a24bedd1"
+     * errorCode = "InvalidInstanceID.NotFound"
+     * errorType = {AmazonServiceException$ErrorType@11247} "Unknown"
+     * errorMessage = "The instance ID 'i-1233f' does not exist"
+     * </code>
+     * <p>
+     * Multiple instances
+     * <code>
+     * ex = {AmazonEC2Exception@11233} "com.amazonaws.services.ec2.model.AmazonEC2Exception: The instance IDs 'i-1233f, i-ffffff' do not exist (Service: AmazonEC2; Status Code: 400; Error Code: InvalidInstanceID.NotFound; Request ID:)"
+     * requestId = "1a353313-ef52-4626-b87b-fd828db6343f"
+     * errorCode = "InvalidInstanceID.NotFound"
+     * errorType = {AmazonServiceException$ErrorType@11251} "Unknown"
+     * errorMessage = "The instance IDs 'i-1233f, i-ffffff' do not exist"
+     * </code>
+     */
+    @Test
+    public void shouldHandleAmazonEc2NotFoundErrorAsTerminatedInstancesAndRetry() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i-1");
+        instanceIds.add("i-f");
+        instanceIds.add("i-3");
+
+        AmazonEC2Exception notFoundException = new AmazonEC2Exception(
+                "The instance IDs 'i-1, i-f' do not exist");
+        notFoundException.setErrorCode("InvalidInstanceID.NotFound");
+
+        DescribeInstancesResult describeInstancesResult2 = new DescribeInstancesResult()
+                .withReservations(new Reservation().withInstances(
+                        new Instance().withInstanceId("i-3")
+                                .withState(new InstanceState().withName(InstanceStateName.Running))));
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenThrow(notFoundException)
+                .thenReturn(describeInstancesResult2);
+
+        // when
+        final Set<String> terminatedIds = EC2Api.describeTerminated(amazonEC2, instanceIds);
+
+        // then
+        Assert.assertEquals(new HashSet<>(Arrays.asList("i-1", "i-f")), terminatedIds);
+        verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-1", "i-3", "i-f")));
+        verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-3")));
+        verifyNoMoreInteractions(amazonEC2);
+    }
+
+    @Test
+    public void shouldFailIfNotAbleToParseNotFoundExceptionFromEc2Api() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i-1");
+        instanceIds.add("i-f");
+        instanceIds.add("i-3");
+
+        AmazonEC2Exception notFoundException = new AmazonEC2Exception(
+                "unparseable");
+        notFoundException.setErrorCode("InvalidInstanceID.NotFound");
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenThrow(notFoundException);
+
+        // when
+        try {
+            EC2Api.describeTerminated(amazonEC2, instanceIds);
+            Assert.fail();
+        } catch (AmazonEC2Exception exception) {
+            Assert.assertSame(notFoundException, exception);
+        }
+    }
+
+    @Test
+    public void shouldThrowExceptionIfEc2DescribeFailsWithException() {
+        // given
+        Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("a");
+
+        UnsupportedOperationException exception = new UnsupportedOperationException("test");
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
+                .thenThrow(exception);
+
+        // when
+        try {
+            EC2Api.describeTerminated(amazonEC2, instanceIds);
+            Assert.fail();
+        } catch (UnsupportedOperationException e) {
+            Assert.assertSame(exception, e);
+        }
+    }
+
+    @Ignore("manual test pass credentials if you want to run")
+    @Test
+    public void realShouldHandleAmazonEc2NotFoundErrorAsTerminatedInstancesAndRetry() {
+        // given
+        final String accessKey = "...";
+        final String secretKey = "...";
+
+        final Set<String> instanceIds = new HashSet<>();
+        instanceIds.add("i-1233f");
+        instanceIds.add("i-ff");
+
+        final AmazonEC2 amazonEC2 = new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey));
+
+        // when
+        Set<String> t = EC2Api.describeTerminated(amazonEC2, instanceIds);
+        Assert.assertEquals(instanceIds, t);
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -1,0 +1,49 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import hudson.PluginWrapper;
+import hudson.slaves.Cloud;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Detailed guides https://jenkins.io/doc/developer/testing/
+ * https://wiki.jenkins.io/display/JENKINS/Unit+Test#UnitTest-DealingwithproblemsinJavaScript
+ */
+public class IntegrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
+    @Test
+    public void shouldFindThePluginByShortName() {
+        PluginWrapper wrapper = j.getPluginManager().getPlugin("ec2-fleet");
+        assertNotNull("should have a valid plugin", wrapper);
+    }
+
+    @Test
+    public void shouldShowInConfigurationClouds() throws IOException, SAXException {
+        Cloud cloud = new EC2FleetCloud(null, null, null, null,
+                null, null, null, false, false,
+                0, 0, 0, 0);
+        j.jenkins.clouds.add(cloud);
+
+        HtmlPage page = j.createWebClient().goTo("configure");
+        System.out.println(page);
+
+        assertEquals("ec2-fleet", ((HtmlTextInput) page.getElementsByName("_.labelString").get(1)).getText());
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -1,10 +1,26 @@
 package com.amazon.jenkins.ec2fleet;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.CancelSpotFleetRequestsRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
+import com.amazonaws.services.ec2.model.RequestSpotFleetRequest;
+import com.amazonaws.services.ec2.model.RequestSpotFleetResult;
+import com.amazonaws.services.ec2.model.SpotFleetLaunchSpecification;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
 import hudson.PluginWrapper;
 import hudson.slaves.Cloud;
+import org.apache.commons.lang.StringUtils;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
@@ -12,6 +28,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -24,6 +43,7 @@ public class IntegrationTest {
 
     @Rule
     public JenkinsRule j = new JenkinsRule();
+
     @ClassRule
     public static BuildWatcher bw = new BuildWatcher();
 
@@ -44,6 +64,118 @@ public class IntegrationTest {
         System.out.println(page);
 
         assertEquals("ec2-fleet", ((HtmlTextInput) page.getElementsByName("_.labelString").get(1)).getText());
+    }
+
+    @Ignore
+    @Test
+    public void shouldSuccessfullyUpdatePluginWithFleetStatus() throws Exception {
+        int targetCapacity = 0;
+
+        final AWSCredentials awsCredentials = getAwsCredentials();
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new AWSCredentialsImpl(CredentialsScope.SYSTEM, "credId",
+                        awsCredentials.getAWSAccessKeyId(), awsCredentials.getAWSSecretKey(), "d"));
+
+        withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
+            @Override
+            public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
+                EC2FleetCloud cloud = new EC2FleetCloud("credId", null, null, fleetId,
+                        null, null, null, false, false,
+                        0, 0, 0, 0);
+                j.jenkins.clouds.add(cloud);
+
+                // 10 sec refresh time so wait
+                Thread.sleep(TimeUnit.SECONDS.toMillis(60));
+
+                assertEquals(0, cloud.getStatusCache().getNumActive());
+                assertEquals(fleetId, cloud.getStatusCache().getFleetId());
+            }
+        });
+    }
+
+    /**
+     * Related to https://github.com/jenkinsci/ec2-fleet-plugin/issues/60
+     *
+     * @throws Exception e
+     */
+    @Ignore
+    @Test
+    public void shouldSuccessfullyUpdateBigFleetPluginWithFleetStatus() throws Exception {
+        final int targetCapacity = 30;
+
+        final AWSCredentials awsCredentials = getAwsCredentials();
+
+        SystemCredentialsProvider.getInstance().getCredentials().add(
+                new AWSCredentialsImpl(CredentialsScope.SYSTEM, "credId",
+                        awsCredentials.getAWSAccessKeyId(), awsCredentials.getAWSSecretKey(), "d"));
+
+        withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
+            @Override
+            public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
+                EC2FleetCloud cloud = new EC2FleetCloud("credId", null, null, fleetId,
+                        null, null, null, false, false,
+                        0, 0, 0, 0);
+                j.jenkins.clouds.add(cloud);
+
+                final long start = System.currentTimeMillis();
+                final long max = TimeUnit.MINUTES.toMillis(2);
+                while (System.currentTimeMillis() - start < max) {
+                    if (cloud.getStatusCache().getNumActive() >= targetCapacity) break;
+                    Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+                }
+
+                assertEquals(targetCapacity, cloud.getStatusCache().getNumActive());
+                assertEquals(fleetId, cloud.getStatusCache().getFleetId());
+            }
+        });
+    }
+
+    private interface WithFleetBody {
+        void run(AmazonEC2 amazonEC2, String fleetId) throws Exception;
+    }
+
+    private void withFleet(AWSCredentials awsCredentials, int targetCapacity, WithFleetBody body) throws Exception {
+        final AmazonEC2 amazonEC2 = new AmazonEC2Client(awsCredentials);
+
+        final SpotFleetRequestConfigData data = new SpotFleetRequestConfigData();
+        data.setLaunchSpecifications(Arrays.asList(
+                new SpotFleetLaunchSpecification()
+                        .withInstanceType("t2.micro")
+                        .withImageId("ami-009d6802948d06e52")
+        ));
+        data.setIamFleetRole("arn:aws:iam::...:role/aws-service-role/spotfleet.amazonaws.com/AWSServiceRoleForEC2SpotFleet");
+        data.setTargetCapacity(targetCapacity);
+
+        final RequestSpotFleetResult result = amazonEC2.requestSpotFleet(
+                new RequestSpotFleetRequest().withSpotFleetRequestConfig(data));
+
+        try {
+            final List<SpotFleetRequestConfig> configs = amazonEC2.describeSpotFleetRequests(
+                    new DescribeSpotFleetRequestsRequest().withSpotFleetRequestIds(
+                            result.getSpotFleetRequestId())).getSpotFleetRequestConfigs();
+
+            if (configs.isEmpty()) throw new IllegalArgumentException();
+
+            final int f = configs.get(0).getSpotFleetRequestConfig().getFulfilledCapacity().intValue();
+            System.out.println("Fulfilment " + f);
+
+            body.run(amazonEC2, result.getSpotFleetRequestId());
+        } finally {
+            amazonEC2.cancelSpotFleetRequests(new CancelSpotFleetRequestsRequest()
+                    .withSpotFleetRequestIds(result.getSpotFleetRequestId()).withTerminateInstances(true));
+        }
+    }
+
+    private AWSCredentials getAwsCredentials() {
+        final String accessKey = System.getProperty("AWS_ACCESS_KEY");
+        final String secretKey = System.getProperty("AWS_SECRET_KEY");
+
+        if (StringUtils.isBlank(accessKey) || StringUtils.isBlank(secretKey)) {
+            throw new IllegalArgumentException("AWS_ACCESS_KEY or AWS_SECRET_KEY is not specified in system properties, -D");
+        }
+
+        return new BasicAWSCredentials(accessKey, secretKey);
     }
 
 }


### PR DESCRIPTION
### Problem
Some users get ```RequestLimitExceeded``` issue #60 when they have more than one fleet. Need to reduce the number of calls to EC2 API to avoid exception but keep updating rating as is if possible so avoid dead executors on Jenkins side. 

### Issue
The actual issue is ```EC2FleetCloud.updateStatus(...)``` method which checks if instances for the fleet were terminated, non-fixed version does one call to EC2 API per instance, each ```10 sec```, as a result, if you reach some number of instances you reach the limit of calls to EC2 API. Doesn't matter if you have a big fleet or a few small.

### Fix
In fact, EC2 API for describe instances supports batch mode [here](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html) which could significantly reduce the amount of calls.

With fix plugin will perform (assume fleet size < 900 instances)  in average ```fleetNumber x seconds_in_day / 10 = fleetNumber x 8640``` API calls to EC2 API.