### PR TITLE
#36 don't reclaim node if not idle now

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -27,7 +27,6 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer> {
         this.maxIdleMinutes = cloud.getIdleMinutes();
         this.alwaysReconnect = cloud.isAlwaysReconnect();
         this.cloud = cloud;
-        LOGGER.log(Level.INFO, "Idle Retention initiated");
     }
 
     @Override
@@ -41,7 +40,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer> {
             boolean justTerminated = false;
             c.setAcceptingTasks(false);
             try {
-                if (isIdleForTooLong(c)) {
+                if (c.isIdle() && isIdleForTooLong(c)) {
                     // Find instance ID
                     Node compNode = c.getNode();
                     if (compNode == null) {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategyTest.java
@@ -2,9 +2,11 @@ package com.amazon.jenkins.ec2fleet;
 
 import hudson.model.Slave;
 import hudson.slaves.SlaveComputer;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -13,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -30,9 +33,19 @@ public class IdleRetentionStrategyTest {
     @Mock
     private Slave slave;
 
+    @Before
+    public void before() {
+        when(cloud.getIdleMinutes()).thenReturn(10);
+        PowerMockito.when(slaveComputer.getIdleStartMilliseconds()).thenReturn(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(11));
+        when(slaveComputer.getNode()).thenReturn(slave);
+        PowerMockito.when(slaveComputer.isIdle()).thenReturn(true);
+        when(slave.getNodeName()).thenReturn("n-a");
+        when(slaveComputer.isAcceptingTasks()).thenReturn(true);
+    }
+
     @Test
     public void if_idle_time_not_configured_should_do_nothing() {
-        when(slaveComputer.isAcceptingTasks()).thenReturn(true);
+        when(cloud.getIdleMinutes()).thenReturn(0);
 
         new IdleRetentionStrategy(cloud).check(slaveComputer);
 
@@ -44,9 +57,19 @@ public class IdleRetentionStrategyTest {
 
     @Test
     public void if_idle_time_configured_should_do_nothing_if_node_idle_less_time() {
-        when(slaveComputer.isAcceptingTasks()).thenReturn(true);
-        when(cloud.getIdleMinutes()).thenReturn(10);
         when(slaveComputer.getIdleStartMilliseconds()).thenReturn(System.currentTimeMillis());
+
+        new IdleRetentionStrategy(cloud).check(slaveComputer);
+
+        verify(slaveComputer, never()).getNode();
+        verify(cloud, never()).terminateInstance(anyString());
+        verify(slaveComputer).setAcceptingTasks(false);
+        verify(slaveComputer).setAcceptingTasks(true);
+    }
+
+    @Test
+    public void if_node_not_execute_anything_yet_idle_time_negative_do_nothing() {
+        when(slaveComputer.getIdleStartMilliseconds()).thenReturn(Long.MIN_VALUE);
 
         new IdleRetentionStrategy(cloud).check(slaveComputer);
 
@@ -58,26 +81,39 @@ public class IdleRetentionStrategyTest {
 
     @Test
     public void if_idle_time_configured_should_terminate_node_if_idle_time_more_then_allowed() {
-        when(cloud.getIdleMinutes()).thenReturn(10);
-        when(slaveComputer.getIdleStartMilliseconds()).thenReturn(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(11));
-        when(slaveComputer.getNode()).thenReturn(slave);
-        when(slave.getNodeName()).thenReturn("n-a");
-
         new IdleRetentionStrategy(cloud).check(slaveComputer);
 
         verify(cloud, times(1)).terminateInstance("n-a");
-        verify(slaveComputer, times(2)).setAcceptingTasks(false);
-        verify(slaveComputer, times(0)).setAcceptingTasks(true);
+        verify(slaveComputer, times(1)).setAcceptingTasks(true);
+        verify(slaveComputer, times(1)).setAcceptingTasks(false);
+    }
+
+    @Test
+    public void if_node_not_idle_should_do_nothing() {
+        when(slaveComputer.getIdleStartMilliseconds()).thenReturn(0L);
+        when(slaveComputer.isIdle()).thenReturn(false);
+
+        new IdleRetentionStrategy(cloud).check(slaveComputer);
+
+        verify(cloud, never()).terminateInstance("n-a");
+        verify(slaveComputer, times(1)).setAcceptingTasks(true);
+        verify(slaveComputer, times(1)).setAcceptingTasks(false);
+    }
+
+    @Test
+    public void if_node_idle_time_more_them_allowed_but_not_idle_should_do_nothing() {
+        when(slaveComputer.isIdle()).thenReturn(false);
+
+        new IdleRetentionStrategy(cloud).check(slaveComputer);
+
+        verify(cloud, never()).terminateInstance("n-a");
+        verify(slaveComputer, times(1)).setAcceptingTasks(true);
+        verify(slaveComputer, times(1)).setAcceptingTasks(false);
     }
 
     @Test
     public void if_exception_happen_during_termination_should_throw_it_and_restore_task_accepting() {
         when(cloud.terminateInstance(anyString())).thenThrow(new IllegalArgumentException("test"));
-        when(cloud.getIdleMinutes()).thenReturn(10);
-        when(slaveComputer.isAcceptingTasks()).thenReturn(true);
-        when(slaveComputer.getIdleStartMilliseconds()).thenReturn(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(11));
-        when(slaveComputer.getNode()).thenReturn(slave);
-        when(slave.getNodeName()).thenReturn("n-a");
 
         try {
             new IdleRetentionStrategy(cloud).check(slaveComputer);


### PR DESCRIPTION
Include into ```IdleRetentionStrategy``` check for ```isIdle()``` which report ```false``` if node executes smt right now, additional to ```getIdleStartMilliseconds()``` which could return ```Long.MIN_VALUE``` in some cases, as result node will be assumed as idle. 

Based on Jenkins [CloudRetentionStrategy](https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/slaves/CloudRetentionStrategy.java)