### PR TITLE
Allow custom endpoint and fix region list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
 
   <developers>
     <developer>
-      <id>cyberax</id>
-      <name>Aleksei Besogonov</name>
-      <email>cyberax@amazon.com</email>
+      <id>terma</id>
+      <name>Artem Stasiuk</name>
+      <email>artem.stasuk@gmail.com</email>
     </developer>
     <developer>
       <id>schmutze</id>
@@ -72,7 +72,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.119</version>
+      <version>1.11.341</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -9,16 +9,22 @@
     <f:entry title="${%Name}" field="name">
         <f:textbox default="FleetCloud"/>
     </f:entry>
+
     <f:entry title="${%AWS Credentials}" field="awsCredentialsId">
       <c:select/>
     </f:entry>
 
-    <f:description>The regions will be populated once the keys above are entered.</f:description>
+    <f:description>Select <a href="https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region">China region</a> for China credentials.</f:description>
     <f:entry title="${%Region}" field="region">
       <f:select/>
     </f:entry>
 
-    <f:description>Fleet list will be available once the connection is validated</f:description>
+    <f:description>Endpoint like https://ec2.us-east-2.amazonaws.com</f:description>
+    <f:entry title="${%Endpoint}" field="endpoint">
+      <f:textbox default=""/>
+    </f:entry>
+
+    <f:description>Fleet list will be available once region and credentials are specified</f:description>
     <f:entry title="${%Spot Fleet}" field="fleet">
         <f:select/>
     </f:entry>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-endpoint.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-endpoint.html
@@ -1,0 +1,13 @@
+Optional field, only required if you cannot find proper region in regions list.
+<p>
+    Please specify endpoint for service <b>EC2</b>, example:
+    <p>
+    <code>
+        https://ec2.cn-northwest-1.amazonaws.com.cn<br>
+        https://ec2.ap-northeast-1.amazonaws.com
+    </code>
+</p>
+<p>
+    List of all available endpoints for EC2 you can find:
+    <a href="https://docs.aws.amazon.com/general/latest/gr/rande.html">Amazon AWS documentation</a>
+</p>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -299,4 +299,32 @@ public class EC2ApiTest {
         Assert.assertEquals(instanceIds, t);
     }
 
+    @Test
+    public void getEndpoint_returnNullIfRegionNameOrEndpointAreEmpty() {
+        Assert.assertNull(new EC2Api().getEndpoint(null, null));
+    }
+
+    @Test
+    public void getEndpoint_returnEnpointAsIsIfProvided() {
+        Assert.assertEquals("mymy", new EC2Api().getEndpoint(null, "mymy"));
+    }
+
+    @Test
+    public void getEndpoint_returnCraftedIfRegionNotInStatic() {
+        Assert.assertEquals("https://ec2.non-real-region.amazonaws.com",
+                new EC2Api().getEndpoint("non-real-region", null));
+    }
+
+    @Test
+    public void getEndpoint_returnCraftedChinaIfRegionNotInStatic() {
+        Assert.assertEquals("https://ec2.cn-non-real.amazonaws.com.cn",
+                new EC2Api().getEndpoint("cn-non-real", null));
+    }
+
+    @Test
+    public void getEndpoint_returnStaticRegionEndpoint() {
+        Assert.assertEquals("https://ec2.cn-north-1.amazonaws.com.cn",
+                new EC2Api().getEndpoint("cn-north-1", null));
+    }
+
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -1,16 +1,19 @@
 package com.amazon.jenkins.ec2fleet;
 
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.ActiveInstance;
 import com.amazonaws.services.ec2.model.BatchState;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesResult;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
 import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsResult;
 import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Region;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
@@ -23,13 +26,14 @@ import hudson.slaves.NodeProvisioner;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
 import jenkins.model.Nodes;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import org.mockito.Mock;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -39,15 +43,17 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.when;
 
 @SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, AmazonEC2Client.class, EC2Api.class, EC2FleetCloud.class,
-        EC2FleetCloud.DescriptorImpl.class, LabelFinder.class})
+@PrepareForTest({Jenkins.class, EC2FleetCloud.class, EC2FleetCloud.DescriptorImpl.class, LabelFinder.class})
 public class EC2FleetCloudTest {
 
     private SpotFleetRequestConfig spotFleetRequestConfig1;
@@ -57,6 +63,12 @@ public class EC2FleetCloudTest {
     private SpotFleetRequestConfig spotFleetRequestConfig5;
     private SpotFleetRequestConfig spotFleetRequestConfig6;
     private SpotFleetRequestConfig spotFleetRequestConfig7;
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Mock
+    private EC2Api ec2Api;
 
     @Before
     public void before() {
@@ -74,6 +86,11 @@ public class EC2FleetCloudTest {
         spotFleetRequestConfig6.setSpotFleetRequestState(BatchState.Cancelled_terminating);
         spotFleetRequestConfig7 = new SpotFleetRequestConfig();
         spotFleetRequestConfig7.setSpotFleetRequestState(BatchState.Failed);
+
+        Registry.setEc2Api(ec2Api);
+
+        PowerMockito.mockStatic(Jenkins.class);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
     }
 
     @After
@@ -84,12 +101,8 @@ public class EC2FleetCloudTest {
     @Test
     public void provision_fleetIsEmpty() {
         // given
-        PowerMockito.mockStatic(Jenkins.class, EC2Api.class);
-
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        EC2Api ec2Api = mock(EC2Api.class);
-        Registry.setEc2Api(ec2Api);
-        when(ec2Api.connect(any(String.class), any(String.class))).thenReturn(amazonEC2);
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         DescribeSpotFleetInstancesResult describeSpotFleetInstancesResult = new DescribeSpotFleetInstancesResult();
         when(amazonEC2.describeSpotFleetInstances(any(DescribeSpotFleetInstancesRequest.class)))
@@ -104,29 +117,22 @@ public class EC2FleetCloudTest {
         when(amazonEC2.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
                 .thenReturn(describeSpotFleetRequestsResult);
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
-                null, null, null, null, false,
+                "", null, null, null, null, false,
                 false, 0, 0, 1, 1, false, false);
 
         // when
         Collection<NodeProvisioner.PlannedNode> r = fleetCloud.provision(null, 1);
 
         // then
-        Assert.assertEquals(1, r.size());
+        assertEquals(1, r.size());
     }
 
     @Test
     public void updateStatus_doNothingWhenFleetIsEmpty() {
         // given
-        PowerMockito.mockStatic(Jenkins.class, EC2Api.class);
-
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        EC2Api ec2Api = mock(EC2Api.class);
-        Registry.setEc2Api(ec2Api);
-        when(ec2Api.connect(any(String.class), any(String.class))).thenReturn(amazonEC2);
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         DescribeSpotFleetInstancesResult describeSpotFleetInstancesResult = new DescribeSpotFleetInstancesResult();
         when(amazonEC2.describeSpotFleetInstances(any(DescribeSpotFleetInstancesRequest.class)))
@@ -141,31 +147,26 @@ public class EC2FleetCloudTest {
         when(amazonEC2.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
                 .thenReturn(describeSpotFleetRequestsResult);
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
-                "fleetId", null, null, null, false,
+                "", "fleetId", null, null, null, false,
                 false, 0, 0, 1, 1, false, false);
 
         // when
         FleetStateStats stats = fleetCloud.updateStatus();
 
         // then
-        Assert.assertEquals(0, stats.getNumDesired());
-        Assert.assertEquals(0, stats.getNumActive());
-        Assert.assertEquals("fleetId", stats.getFleetId());
+        assertEquals(0, stats.getNumDesired());
+        assertEquals(0, stats.getNumActive());
+        assertEquals("fleetId", stats.getFleetId());
     }
 
     @Test
     public void updateStatus_shouldAddNodeIfAnyNewDescribed() throws IOException {
         // given
-        PowerMockito.mockStatic(Jenkins.class, EC2Api.class, LabelFinder.class);
+        PowerMockito.mockStatic(LabelFinder.class);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        EC2Api ec2Api = mock(EC2Api.class);
-        Registry.setEc2Api(ec2Api);
-        when(ec2Api.connect(any(String.class), any(String.class))).thenReturn(amazonEC2);
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         DescribeInstancesResult describeInstancesResult = new DescribeInstancesResult();
         describeInstancesResult.withReservations(
@@ -193,9 +194,7 @@ public class EC2FleetCloudTest {
         when(amazonEC2.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
                 .thenReturn(describeSpotFleetRequestsResult);
 
-        Jenkins jenkins = mock(Jenkins.class);
-        Mockito.when(jenkins.getNodesObject()).thenReturn(mock(Nodes.class));
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getNodesObject()).thenReturn(mock(Nodes.class));
 
         // mock
         ExtensionList labelFinder = mock(ExtensionList.class);
@@ -203,37 +202,35 @@ public class EC2FleetCloudTest {
         PowerMockito.when(LabelFinder.all()).thenReturn(labelFinder);
 
         // mocking part of node creation process Jenkins.getInstance().getLabelAtom(l)
-        Mockito.when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
+        when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
-                "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
+                "", "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
-        Mockito.doNothing().when(jenkins).addNode(nodeCaptor.capture());
+        doNothing().when(jenkins).addNode(nodeCaptor.capture());
 
         // when
         FleetStateStats stats = fleetCloud.updateStatus();
 
         // then
-        Assert.assertEquals(0, stats.getNumDesired());
-        Assert.assertEquals(1, stats.getNumActive());
-        Assert.assertEquals("fleetId", stats.getFleetId());
+        assertEquals(0, stats.getNumDesired());
+        assertEquals(1, stats.getNumActive());
+        assertEquals("fleetId", stats.getFleetId());
 
         // and
         Node actualFleetNode = nodeCaptor.getValue();
-        Assert.assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
+        assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
 
     @Test
     public void updateStatus_shouldAddNodeIfAnyNewDescribed_restrictUsage() throws IOException {
         // given
-        PowerMockito.mockStatic(Jenkins.class, EC2Api.class, LabelFinder.class);
+        PowerMockito.mockStatic(LabelFinder.class);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        EC2Api ec2Api = mock(EC2Api.class);
-        Registry.setEc2Api(ec2Api);
-        when(ec2Api.connect(any(String.class), any(String.class))).thenReturn(amazonEC2);
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         DescribeInstancesResult describeInstancesResult = new DescribeInstancesResult();
         describeInstancesResult.withReservations(
@@ -261,9 +258,7 @@ public class EC2FleetCloudTest {
         when(amazonEC2.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
                 .thenReturn(describeSpotFleetRequestsResult);
 
-        Jenkins jenkins = mock(Jenkins.class);
-        Mockito.when(jenkins.getNodesObject()).thenReturn(mock(Nodes.class));
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getNodesObject()).thenReturn(mock(Nodes.class));
 
         // mock
         ExtensionList labelFinder = mock(ExtensionList.class);
@@ -271,48 +266,78 @@ public class EC2FleetCloudTest {
         PowerMockito.when(LabelFinder.all()).thenReturn(labelFinder);
 
         // mocking part of node creation process Jenkins.getInstance().getLabelAtom(l)
-        Mockito.when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
+        when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
-                "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
+                "", "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false, true);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
-        Mockito.doNothing().when(jenkins).addNode(nodeCaptor.capture());
+        doNothing().when(jenkins).addNode(nodeCaptor.capture());
 
         // when
         FleetStateStats stats = fleetCloud.updateStatus();
 
         // then
-        Assert.assertEquals(0, stats.getNumDesired());
-        Assert.assertEquals(1, stats.getNumActive());
-        Assert.assertEquals("fleetId", stats.getFleetId());
+        assertEquals(0, stats.getNumDesired());
+        assertEquals(1, stats.getNumActive());
+        assertEquals("fleetId", stats.getFleetId());
 
         // and
         Node actualFleetNode = nodeCaptor.getValue();
-        Assert.assertEquals(Node.Mode.EXCLUSIVE, actualFleetNode.getMode());
+        assertEquals(Node.Mode.EXCLUSIVE, actualFleetNode.getMode());
+    }
+
+    @Test
+    public void descriptorImpl_doFillRegionItems_returnStaticRegionsIfApiCallFailed() {
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillRegionItems("");
+
+        Assert.assertThat(r.size(), Matchers.greaterThan(0));
+        assertEquals(RegionUtils.getRegions().size(), r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillRegionItems_returnStaticRegionsAndDynamic() {
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        when(ec2Api.connect(anyString(), nullable(String.class), nullable(String.class))).thenReturn(amazonEC2Client);
+        when(amazonEC2Client.describeRegions()).thenReturn(new DescribeRegionsResult().withRegions(new Region().withRegionName("dynamic-region")));
+
+        ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillRegionItems("");
+
+        Assert.assertThat(r.size(), Matchers.greaterThan(0));
+        Assert.assertThat(r.toString(), Matchers.containsString("dynamic-region"));
+        assertEquals(RegionUtils.getRegions().size() + 1, r.size());
+    }
+
+    @Test
+    public void descriptorImpl_doFillRegionItems_returnConsistOrderBetweenCalls() {
+        AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
+        when(ec2Api.connect(anyString(), nullable(String.class), nullable(String.class))).thenReturn(amazonEC2Client);
+        when(amazonEC2Client.describeRegions()).thenReturn(new DescribeRegionsResult().withRegions(new Region().withRegionName("dynamic-region")));
+
+        ListBoxModel r1 = new EC2FleetCloud.DescriptorImpl().doFillRegionItems("");
+        ListBoxModel r2 = new EC2FleetCloud.DescriptorImpl().doFillRegionItems("");
+        ListBoxModel r3 = new EC2FleetCloud.DescriptorImpl().doFillRegionItems("");
+
+        assertEquals(r1.toString(), r2.toString());
+        assertEquals(r2.toString(), r3.toString());
     }
 
     @Test
     public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoFleetInAccount() {
-        PowerMockito.mockStatic(Jenkins.class);
-
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals(0, r.size());
+        assertEquals(0, r.size());
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoActiveFleets() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoActiveFleets() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -322,22 +347,16 @@ public class EC2FleetCloudTest {
                 .thenReturn(Arrays.asList(spotFleetRequestConfig4, spotFleetRequestConfig5,
                         spotFleetRequestConfig6, spotFleetRequestConfig7));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals(0, r.size());
+        assertEquals(0, r.size());
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnActiveFleets() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnActiveFleets() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -348,22 +367,16 @@ public class EC2FleetCloudTest {
                         spotFleetRequestConfig3, spotFleetRequestConfig4, spotFleetRequestConfig5,
                         spotFleetRequestConfig6, spotFleetRequestConfig7));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals(3, r.size());
+        assertEquals(3, r.size());
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnAllFleetsIfShowNonActiveIsEnabled() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnAllFleetsIfShowNonActiveIsEnabled() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -374,22 +387,16 @@ public class EC2FleetCloudTest {
                         spotFleetRequestConfig3, spotFleetRequestConfig4, spotFleetRequestConfig5,
                         spotFleetRequestConfig6, spotFleetRequestConfig7));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                true, "", "", "");
+                true, "", "", "", "");
 
-        Assert.assertEquals(7, r.size());
+        assertEquals(7, r.size());
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnFleetInfo() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnFleetInfo() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -400,23 +407,17 @@ public class EC2FleetCloudTest {
         when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
                 .thenReturn(Arrays.asList(spotFleetRequestConfig1));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals("fleet-id (active)", r.get(0).name);
-        Assert.assertEquals("fleet-id", r.get(0).value);
+        assertEquals("fleet-id (active)", r.get(0).name);
+        assertEquals("fleet-id", r.get(0).value);
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnFleetsCrossPages() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnFleetsCrossPages() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -436,24 +437,18 @@ public class EC2FleetCloudTest {
                 .thenReturn(Arrays.asList(spotFleetRequestConfig2))
                 .thenReturn(Arrays.asList(spotFleetRequestConfig3));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals("a", r.get(0).value);
-        Assert.assertEquals("b", r.get(1).value);
-        Assert.assertEquals("c", r.get(2).value);
+        assertEquals("a", r.get(0).value);
+        assertEquals("b", r.get(1).value);
+        assertEquals("c", r.get(2).value);
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnSelectedFleetInAnyState() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
+    public void descriptorImpl_doFillFleetItems_returnSelectedFleetInAnyState() {
         AmazonEC2Client amazonEC2Client = mock(AmazonEC2Client.class);
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenReturn(amazonEC2Client);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2Client);
 
         DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = mock(DescribeSpotFleetRequestsResult.class);
         when(amazonEC2Client.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
@@ -466,56 +461,47 @@ public class EC2FleetCloudTest {
         when(describeSpotFleetRequestsResult.getSpotFleetRequestConfigs())
                 .thenReturn(Arrays.asList(spotFleetRequestConfig1, spotFleetRequestConfig2));
 
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
-
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "failed_selected");
+                false, "", "", "", "failed_selected");
 
-        Assert.assertEquals("a", r.get(0).value);
-        Assert.assertEquals("failed_selected", r.get(1).value);
+        assertEquals("a", r.get(0).value);
+        assertEquals("failed_selected", r.get(1).value);
     }
 
     @Test
-    public void descriptorImpl_doFillFleetItems_returnEmptyListIfAnyException() throws Exception {
-        PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.mockStatic(AmazonEC2Client.class);
-
-        PowerMockito.whenNew(AmazonEC2Client.class).withNoArguments().thenThrow(new IllegalArgumentException("test"));
-
-        Jenkins jenkins = mock(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+    public void descriptorImpl_doFillFleetItems_returnEmptyListIfAnyException() {
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenThrow(new IllegalArgumentException("test"));
 
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
-                false, "", "", "");
+                false, "", "", "", "");
 
-        Assert.assertEquals(0, r.size());
+        assertEquals(0, r.size());
     }
 
     @Test
     public void getDisplayName_returnDefaultWhenNull() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
-        Assert.assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
+        assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
     }
 
     @Test
     public void getDisplayName_returnDisplayName() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                "CloudName", null, null, null, null,
+                "CloudName", null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
-        Assert.assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
+        assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
     }
 
     @Test
     public void getAwsCredentialsId_returnNull_whenNoCredentialsIdOrAwsCredentialsId() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
@@ -525,31 +511,31 @@ public class EC2FleetCloudTest {
     @Test
     public void getAwsCredentialsId_returnValue_whenCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, null, "Opa", null, null,
+                null, null, "Opa", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
-        Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
+        assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
     @Test
     public void getAwsCredentialsId_returnValue_whenAwsCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, "Opa", null, null, null,
+                null, "Opa", null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
-        Assert.assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
+        assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
     @Test
     public void getAwsCredentialsId_returnAwsCredentialsId_whenAwsCredentialsIdAndCredentialsIdPresent() {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
-                null, "A", "B", null, null,
+                null, "A", "B", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false);
-        Assert.assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
+        assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
     }
 
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EmptyAmazonEC2.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EmptyAmazonEC2.java
@@ -26,6 +26,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public AcceptVpcEndpointConnectionsResult acceptVpcEndpointConnections(AcceptVpcEndpointConnectionsRequest acceptVpcEndpointConnectionsRequest) {
+        return null;
+    }
+
+    @Override
     public AcceptVpcPeeringConnectionResult acceptVpcPeeringConnection(AcceptVpcPeeringConnectionRequest acceptVpcPeeringConnectionRequest) {
         return null;
     }
@@ -176,6 +181,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public CopyFpgaImageResult copyFpgaImage(CopyFpgaImageRequest copyFpgaImageRequest) {
+        return null;
+    }
+
+    @Override
     public CopyImageResult copyImage(CopyImageRequest copyImageRequest) {
         return null;
     }
@@ -191,6 +201,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public CreateDefaultSubnetResult createDefaultSubnet(CreateDefaultSubnetRequest createDefaultSubnetRequest) {
+        return null;
+    }
+
+    @Override
+    public CreateDefaultVpcResult createDefaultVpc(CreateDefaultVpcRequest createDefaultVpcRequest) {
+        return null;
+    }
+
+    @Override
     public CreateDhcpOptionsResult createDhcpOptions(CreateDhcpOptionsRequest createDhcpOptionsRequest) {
         return null;
     }
@@ -201,7 +221,17 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public CreateFleetResult createFleet(CreateFleetRequest createFleetRequest) {
+        return null;
+    }
+
+    @Override
     public CreateFlowLogsResult createFlowLogs(CreateFlowLogsRequest createFlowLogsRequest) {
+        return null;
+    }
+
+    @Override
+    public CreateFpgaImageResult createFpgaImage(CreateFpgaImageRequest createFpgaImageRequest) {
         return null;
     }
 
@@ -231,6 +261,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public CreateLaunchTemplateResult createLaunchTemplate(CreateLaunchTemplateRequest createLaunchTemplateRequest) {
+        return null;
+    }
+
+    @Override
+    public CreateLaunchTemplateVersionResult createLaunchTemplateVersion(CreateLaunchTemplateVersionRequest createLaunchTemplateVersionRequest) {
+        return null;
+    }
+
+    @Override
     public CreateNatGatewayResult createNatGateway(CreateNatGatewayRequest createNatGatewayRequest) {
         return null;
     }
@@ -247,6 +287,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public CreateNetworkInterfaceResult createNetworkInterface(CreateNetworkInterfaceRequest createNetworkInterfaceRequest) {
+        return null;
+    }
+
+    @Override
+    public CreateNetworkInterfacePermissionResult createNetworkInterfacePermission(CreateNetworkInterfacePermissionRequest createNetworkInterfacePermissionRequest) {
         return null;
     }
 
@@ -311,6 +356,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public CreateVpcEndpointConnectionNotificationResult createVpcEndpointConnectionNotification(CreateVpcEndpointConnectionNotificationRequest createVpcEndpointConnectionNotificationRequest) {
+        return null;
+    }
+
+    @Override
+    public CreateVpcEndpointServiceConfigurationResult createVpcEndpointServiceConfiguration(CreateVpcEndpointServiceConfigurationRequest createVpcEndpointServiceConfigurationRequest) {
+        return null;
+    }
+
+    @Override
     public CreateVpcPeeringConnectionResult createVpcPeeringConnection(CreateVpcPeeringConnectionRequest createVpcPeeringConnectionRequest) {
         return null;
     }
@@ -351,7 +406,17 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DeleteFleetsResult deleteFleets(DeleteFleetsRequest deleteFleetsRequest) {
+        return null;
+    }
+
+    @Override
     public DeleteFlowLogsResult deleteFlowLogs(DeleteFlowLogsRequest deleteFlowLogsRequest) {
+        return null;
+    }
+
+    @Override
+    public DeleteFpgaImageResult deleteFpgaImage(DeleteFpgaImageRequest deleteFpgaImageRequest) {
         return null;
     }
 
@@ -362,6 +427,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public DeleteKeyPairResult deleteKeyPair(DeleteKeyPairRequest deleteKeyPairRequest) {
+        return null;
+    }
+
+    @Override
+    public DeleteLaunchTemplateResult deleteLaunchTemplate(DeleteLaunchTemplateRequest deleteLaunchTemplateRequest) {
+        return null;
+    }
+
+    @Override
+    public DeleteLaunchTemplateVersionsResult deleteLaunchTemplateVersions(DeleteLaunchTemplateVersionsRequest deleteLaunchTemplateVersionsRequest) {
         return null;
     }
 
@@ -382,6 +457,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public DeleteNetworkInterfaceResult deleteNetworkInterface(DeleteNetworkInterfaceRequest deleteNetworkInterfaceRequest) {
+        return null;
+    }
+
+    @Override
+    public DeleteNetworkInterfacePermissionResult deleteNetworkInterfacePermission(DeleteNetworkInterfacePermissionRequest deleteNetworkInterfacePermissionRequest) {
         return null;
     }
 
@@ -441,6 +521,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DeleteVpcEndpointConnectionNotificationsResult deleteVpcEndpointConnectionNotifications(DeleteVpcEndpointConnectionNotificationsRequest deleteVpcEndpointConnectionNotificationsRequest) {
+        return null;
+    }
+
+    @Override
+    public DeleteVpcEndpointServiceConfigurationsResult deleteVpcEndpointServiceConfigurations(DeleteVpcEndpointServiceConfigurationsRequest deleteVpcEndpointServiceConfigurationsRequest) {
+        return null;
+    }
+
+    @Override
     public DeleteVpcEndpointsResult deleteVpcEndpoints(DeleteVpcEndpointsRequest deleteVpcEndpointsRequest) {
         return null;
     }
@@ -487,6 +577,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public DescribeAddressesResult describeAddresses() {
+        return null;
+    }
+
+    @Override
+    public DescribeAggregateIdFormatResult describeAggregateIdFormat(DescribeAggregateIdFormatRequest describeAggregateIdFormatRequest) {
         return null;
     }
 
@@ -556,6 +651,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeElasticGpusResult describeElasticGpus(DescribeElasticGpusRequest describeElasticGpusRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeExportTasksResult describeExportTasks(DescribeExportTasksRequest describeExportTasksRequest) {
         return null;
     }
@@ -566,12 +666,37 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeFleetHistoryResult describeFleetHistory(DescribeFleetHistoryRequest describeFleetHistoryRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeFleetInstancesResult describeFleetInstances(DescribeFleetInstancesRequest describeFleetInstancesRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeFleetsResult describeFleets(DescribeFleetsRequest describeFleetsRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeFlowLogsResult describeFlowLogs(DescribeFlowLogsRequest describeFlowLogsRequest) {
         return null;
     }
 
     @Override
     public DescribeFlowLogsResult describeFlowLogs() {
+        return null;
+    }
+
+    @Override
+    public DescribeFpgaImageAttributeResult describeFpgaImageAttribute(DescribeFpgaImageAttributeRequest describeFpgaImageAttributeRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeFpgaImagesResult describeFpgaImages(DescribeFpgaImagesRequest describeFpgaImagesRequest) {
         return null;
     }
 
@@ -656,6 +781,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeInstanceCreditSpecificationsResult describeInstanceCreditSpecifications(DescribeInstanceCreditSpecificationsRequest describeInstanceCreditSpecificationsRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeInstanceStatusResult describeInstanceStatus(DescribeInstanceStatusRequest describeInstanceStatusRequest) {
         return null;
     }
@@ -696,6 +826,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeLaunchTemplateVersionsResult describeLaunchTemplateVersions(DescribeLaunchTemplateVersionsRequest describeLaunchTemplateVersionsRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeLaunchTemplatesResult describeLaunchTemplates(DescribeLaunchTemplatesRequest describeLaunchTemplatesRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeMovingAddressesResult describeMovingAddresses(DescribeMovingAddressesRequest describeMovingAddressesRequest) {
         return null;
     }
@@ -726,6 +866,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeNetworkInterfacePermissionsResult describeNetworkInterfacePermissions(DescribeNetworkInterfacePermissionsRequest describeNetworkInterfacePermissionsRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeNetworkInterfacesResult describeNetworkInterfaces(DescribeNetworkInterfacesRequest describeNetworkInterfacesRequest) {
         return null;
     }
@@ -752,6 +897,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public DescribePrefixListsResult describePrefixLists() {
+        return null;
+    }
+
+    @Override
+    public DescribePrincipalIdFormatResult describePrincipalIdFormat(DescribePrincipalIdFormatRequest describePrincipalIdFormatRequest) {
         return null;
     }
 
@@ -981,6 +1131,26 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public DescribeVpcEndpointConnectionNotificationsResult describeVpcEndpointConnectionNotifications(DescribeVpcEndpointConnectionNotificationsRequest describeVpcEndpointConnectionNotificationsRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeVpcEndpointConnectionsResult describeVpcEndpointConnections(DescribeVpcEndpointConnectionsRequest describeVpcEndpointConnectionsRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeVpcEndpointServiceConfigurationsResult describeVpcEndpointServiceConfigurations(DescribeVpcEndpointServiceConfigurationsRequest describeVpcEndpointServiceConfigurationsRequest) {
+        return null;
+    }
+
+    @Override
+    public DescribeVpcEndpointServicePermissionsResult describeVpcEndpointServicePermissions(DescribeVpcEndpointServicePermissionsRequest describeVpcEndpointServicePermissionsRequest) {
+        return null;
+    }
+
+    @Override
     public DescribeVpcEndpointServicesResult describeVpcEndpointServices(DescribeVpcEndpointServicesRequest describeVpcEndpointServicesRequest) {
         return null;
     }
@@ -1141,6 +1311,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public GetLaunchTemplateDataResult getLaunchTemplateData(GetLaunchTemplateDataRequest getLaunchTemplateDataRequest) {
+        return null;
+    }
+
+    @Override
     public GetPasswordDataResult getPasswordData(GetPasswordDataRequest getPasswordDataRequest) {
         return null;
     }
@@ -1186,6 +1361,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public ModifyFleetResult modifyFleet(ModifyFleetRequest modifyFleetRequest) {
+        return null;
+    }
+
+    @Override
+    public ModifyFpgaImageAttributeResult modifyFpgaImageAttribute(ModifyFpgaImageAttributeRequest modifyFpgaImageAttributeRequest) {
+        return null;
+    }
+
+    @Override
     public ModifyHostsResult modifyHosts(ModifyHostsRequest modifyHostsRequest) {
         return null;
     }
@@ -1211,7 +1396,17 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public ModifyInstanceCreditSpecificationResult modifyInstanceCreditSpecification(ModifyInstanceCreditSpecificationRequest modifyInstanceCreditSpecificationRequest) {
+        return null;
+    }
+
+    @Override
     public ModifyInstancePlacementResult modifyInstancePlacement(ModifyInstancePlacementRequest modifyInstancePlacementRequest) {
+        return null;
+    }
+
+    @Override
+    public ModifyLaunchTemplateResult modifyLaunchTemplate(ModifyLaunchTemplateRequest modifyLaunchTemplateRequest) {
         return null;
     }
 
@@ -1261,7 +1456,27 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
     }
 
     @Override
+    public ModifyVpcEndpointConnectionNotificationResult modifyVpcEndpointConnectionNotification(ModifyVpcEndpointConnectionNotificationRequest modifyVpcEndpointConnectionNotificationRequest) {
+        return null;
+    }
+
+    @Override
+    public ModifyVpcEndpointServiceConfigurationResult modifyVpcEndpointServiceConfiguration(ModifyVpcEndpointServiceConfigurationRequest modifyVpcEndpointServiceConfigurationRequest) {
+        return null;
+    }
+
+    @Override
+    public ModifyVpcEndpointServicePermissionsResult modifyVpcEndpointServicePermissions(ModifyVpcEndpointServicePermissionsRequest modifyVpcEndpointServicePermissionsRequest) {
+        return null;
+    }
+
+    @Override
     public ModifyVpcPeeringConnectionOptionsResult modifyVpcPeeringConnectionOptions(ModifyVpcPeeringConnectionOptionsRequest modifyVpcPeeringConnectionOptionsRequest) {
+        return null;
+    }
+
+    @Override
+    public ModifyVpcTenancyResult modifyVpcTenancy(ModifyVpcTenancyRequest modifyVpcTenancyRequest) {
         return null;
     }
 
@@ -1297,6 +1512,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public RegisterImageResult registerImage(RegisterImageRequest registerImageRequest) {
+        return null;
+    }
+
+    @Override
+    public RejectVpcEndpointConnectionsResult rejectVpcEndpointConnections(RejectVpcEndpointConnectionsRequest rejectVpcEndpointConnectionsRequest) {
         return null;
     }
 
@@ -1352,6 +1572,11 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public RequestSpotInstancesResult requestSpotInstances(RequestSpotInstancesRequest requestSpotInstancesRequest) {
+        return null;
+    }
+
+    @Override
+    public ResetFpgaImageAttributeResult resetFpgaImageAttribute(ResetFpgaImageAttributeRequest resetFpgaImageAttributeRequest) {
         return null;
     }
 
@@ -1432,6 +1657,16 @@ public class EmptyAmazonEC2 implements AmazonEC2 {
 
     @Override
     public UnmonitorInstancesResult unmonitorInstances(UnmonitorInstancesRequest unmonitorInstancesRequest) {
+        return null;
+    }
+
+    @Override
+    public UpdateSecurityGroupRuleDescriptionsEgressResult updateSecurityGroupRuleDescriptionsEgress(UpdateSecurityGroupRuleDescriptionsEgressRequest updateSecurityGroupRuleDescriptionsEgressRequest) {
+        return null;
+    }
+
+    @Override
+    public UpdateSecurityGroupRuleDescriptionsIngressResult updateSecurityGroupRuleDescriptionsIngress(UpdateSecurityGroupRuleDescriptionsIngressRequest updateSecurityGroupRuleDescriptionsIngressRequest) {
         return null;
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -121,8 +121,8 @@ public class ProvisionIntegrationTest {
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
 
-        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
-                "momo", null, computerConnector, false, false,
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 0, 1, false, false);
         j.jenkins.clouds.add(cloud);
 
@@ -130,7 +130,7 @@ public class ProvisionIntegrationTest {
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        when(ec2Api.connect(anyString(), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2);
 
         when(amazonEC2.describeSpotFleetInstances(any(DescribeSpotFleetInstancesRequest.class)))
                 .thenReturn(new DescribeSpotFleetInstancesResult());
@@ -161,8 +161,8 @@ public class ProvisionIntegrationTest {
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
 
-        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
-                "momo", null, computerConnector, false, false,
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false);
         j.jenkins.clouds.add(cloud);
 
@@ -170,7 +170,7 @@ public class ProvisionIntegrationTest {
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        when(ec2Api.connect(anyString(), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2);
 
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
                 .thenReturn(new DescribeInstancesResult());
@@ -230,8 +230,8 @@ public class ProvisionIntegrationTest {
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
 
-        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
-                "momo", null, computerConnector, false, false,
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false);
         j.jenkins.clouds.add(cloud);
 
@@ -239,7 +239,7 @@ public class ProvisionIntegrationTest {
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        when(ec2Api.connect(anyString(), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2);
 
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
                 .then(new Answer<Object>() {
@@ -312,8 +312,8 @@ public class ProvisionIntegrationTest {
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
 
-        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region", "fId",
-                "momo", null, computerConnector, false, false,
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false);
         j.jenkins.clouds.add(cloud);
 
@@ -321,7 +321,7 @@ public class ProvisionIntegrationTest {
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
-        when(ec2Api.connect(anyString(), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.connect(anyString(), anyString(), anyString())).thenReturn(amazonEC2);
 
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
                 .then(new Answer<Object>() {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
@@ -48,7 +48,7 @@ public class RealEc2ApiIntegrationTest {
         withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
             @Override
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
-                EC2FleetCloud cloud = new EC2FleetCloud("", "credId", null, null, fleetId,
+                EC2FleetCloud cloud = new EC2FleetCloud("", "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false);
                 j.jenkins.clouds.add(cloud);
@@ -80,7 +80,7 @@ public class RealEc2ApiIntegrationTest {
         withFleet(awsCredentials, targetCapacity, new WithFleetBody() {
             @Override
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
-                EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, null, fleetId,
+                EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false);
                 j.jenkins.clouds.add(cloud);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -42,7 +42,7 @@ public class UiIntegrationTest {
 
     @Test
     public void shouldShowInConfigurationClouds() throws IOException, SAXException {
-        Cloud cloud = new EC2FleetCloud(null, null, null, null, null,
+        Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud);
@@ -56,12 +56,12 @@ public class UiIntegrationTest {
     @Test
     public void shouldShowMultipleClouds() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud2);
 
@@ -77,12 +77,12 @@ public class UiIntegrationTest {
     @Test
     public void shouldShowMultipleCloudsWithDefaultName() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud2);
 
@@ -98,12 +98,12 @@ public class UiIntegrationTest {
     @Test
     public void shouldUpdateProperCloudWhenMultiple() throws IOException, SAXException {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud2);
 
@@ -121,12 +121,12 @@ public class UiIntegrationTest {
     @Test
     public void shouldGetFirstWhenMultipleCloudWithSameName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud2);
 
@@ -136,12 +136,12 @@ public class UiIntegrationTest {
     @Test
     public void shouldGetProperWhenMultipleWithDiffName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
-                null, null, null, false, false,
+                null, null, null, null, false, false,
                 0, 0, 0, 0, false, false);
         j.jenkins.clouds.add(cloud2);
 


### PR DESCRIPTION
Fix for #103 #51

### Done

1. Make region list on Configuration page as mix of static region list from ```org.jenkins-ci.plugins:aws-java-sdk``` and dynamic call to EC2 ```describeRegions``` to be able provide list even if call fails or doesn't provide required region, like China 
1. Upgrade ```org.jenkins-ci.plugins:aws-java-sdk``` dependency to latest version which still support Jenkins ```1.6.x``` to improve list of regions
1. Allow configure custom ```endpoint``` for case when region list doesn't have proper region.

### UI example

<img width="656" alt="Screen Shot 2019-06-21 at 1 55 59 PM" src="https://user-images.githubusercontent.com/473022/59951398-b3a6c100-942d-11e9-8af2-03c0058a36fd.png">
