### PR TITLE
Fix auto resubmit job if ec2 terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,3 +198,15 @@ https://jenkins.io/doc/developer/publishing/releasing/
 ```bash
 mvn release:prepare release:perform
 ```
+
+### Jenkins 2 can't connect by SSH 
+
+https://issues.jenkins-ci.org/browse/JENKINS-53954
+
+### Install Java 8 on EC2 instance 
+
+```bash
+sudo yum install java-1.8.0
+sudo yum remove java-1.7.0-openjdk
+java -version 
+```

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,6 @@
       </exclusions>
     </dependency>
 
-
   </dependencies>
 
   <build>

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -1,0 +1,118 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.Executor;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.model.queue.SubTask;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.DelegatingComputerLauncher;
+import hudson.slaves.OfflineCause;
+import hudson.slaves.SlaveComputer;
+import hudson.util.StreamTaskListener;
+import jenkins.model.CauseOfInterruption;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This is wrapper for {@link ComputerLauncher} to get notification when slave was disconnected
+ * and automatically resubmit {@link hudson.model.Queue.Task} if reason is unexpected termination
+ * which usually means EC2 instance was interrupted.
+ * <p>
+ * This is optional feature, it's enabled by default, but could be disabled by
+ * {@link EC2FleetCloud#isDisableTaskResubmit()}
+ *
+ * @see EC2FleetNode
+ * @see EC2FleetNodeComputer
+ */
+public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLauncher {
+
+    private static final Level LOG_LEVEL = Level.INFO;
+    private static final Logger LOGGER = Logger.getLogger(EC2FleetAutoResubmitComputerLauncher.class.getName());
+
+    /**
+     * Delay which will be applied when job {@link Queue#scheduleInternal(Queue.Task, int, List)}
+     * rescheduled after offline
+     */
+    private static final int RESCHEDULE_QUIET_PERIOD_SEC = 10;
+
+    private final boolean disableTaskResubmit;
+
+    protected EC2FleetAutoResubmitComputerLauncher(
+            final ComputerLauncher launcher, final boolean disableTaskResubmit) {
+        super(launcher);
+        this.disableTaskResubmit = disableTaskResubmit;
+    }
+
+    /**
+     * {@link ComputerLauncher#afterDisconnect(SlaveComputer, TaskListener)}
+     * <p>
+     * EC2 Fleet plugin overrides this method to detect jobs which were failed because of
+     * EC2 instance was terminated/stopped. It could be manual stop or because of Spot marked.
+     * In all cases as soon as job aborted because of broken connection and slave is offline
+     * it will try to resubmit aborted job back to the queue, so user doesn't need to do that manually
+     * and another slave could take it.
+     * <p>
+     * Implementation details
+     * <p>
+     * There is no official recommendation about way how to resubmit job according to
+     * https://issues.jenkins-ci.org/browse/JENKINS-49707 moreover some of Jenkins code says it impossible.
+     * <p>
+     * method checks {@link SlaveComputer#getOfflineCause()} for disconnect because of EC2 instance termination
+     * it returns
+     * <code>
+     * result = {OfflineCause$ChannelTermination@13708} "Connection was broken: java.io.IOException:
+     * Unexpected termination of the channel\n\tat hudson.remoting.SynchronousCommandTransport$ReaderThread...
+     * cause = {IOException@13721} "java.io.IOException: Unexpected termination of the channel"
+     * timestamp = 1561067177837
+     * </code>
+     *
+     * @param computer computer
+     * @param listener listener
+     */
+    @Override
+    public void afterDisconnect(final SlaveComputer computer, final TaskListener listener) {
+        final boolean unexpectedDisconnect = computer.isOffline() && computer.getOfflineCause() instanceof OfflineCause.ChannelTermination;
+        if (!disableTaskResubmit && unexpectedDisconnect) {
+            final List<Executor> executors = computer.getExecutors();
+            LOGGER.log(LOG_LEVEL, "Unexpected " + computer.getDisplayName()
+                    + " termination,  resubmit");
+
+            for (Executor executor : executors) {
+                if (executor.getCurrentExecutable() != null) {
+                    executor.interrupt(Result.ABORTED, new EC2TerminationCause(computer.getDisplayName()));
+
+                    final Queue.Executable executable = executor.getCurrentExecutable();
+                    // if executor is not idle
+                    if (executable != null) {
+                        final SubTask subTask = executable.getParent();
+                        final Queue.Task task = subTask.getOwnerTask();
+
+                        List<Action> actions = new ArrayList<>();
+                        if (executable instanceof Actionable) {
+                            actions = ((Actionable) executable).getActions();
+                        }
+
+                        Queue.getInstance().schedule2(task, RESCHEDULE_QUIET_PERIOD_SEC, actions);
+                        LOGGER.log(LOG_LEVEL, "Unexpected " + computer.getDisplayName()
+                                + " termination, resubmit " + task + " with actions " + actions);
+                    }
+                }
+            }
+            LOGGER.log(LOG_LEVEL, "Unexpected " + computer.getDisplayName()
+                    + " termination, resubmit finished");
+        } else {
+            LOGGER.log(LOG_LEVEL, "Unexpected " + computer.getDisplayName()
+                    + " termination but resubmit disabled, no actions");
+        }
+
+        // call parent
+        super.afterDisconnect(computer, listener);
+    }
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -1,27 +1,15 @@
 package com.amazon.jenkins.ec2fleet;
 
-import hudson.model.Executor;
-import hudson.model.Queue;
 import hudson.model.Slave;
-import hudson.slaves.OfflineCause;
 import hudson.slaves.SlaveComputer;
 
 import javax.annotation.Nonnull;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * @see EC2FleetNode
+ * @see EC2FleetAutoResubmitComputerLauncher
  */
 public class EC2FleetNodeComputer extends SlaveComputer {
-
-    /**
-     * Delay which will be applied when job {@link Queue#scheduleInternal(Queue.Task, int, List)}
-     * rescheduled after offline
-     */
-    private static final int RESCHEDULE_QUIET_PERIOD_SEC = 10;
-
-    private static final Logger LOGGER = Logger.getLogger(EC2FleetNodeComputer.class.getName());
 
     public EC2FleetNodeComputer(final Slave slave) {
         super(slave);
@@ -45,43 +33,6 @@ public class EC2FleetNodeComputer extends SlaveComputer {
         // getNode() hit map to find node by name
         final EC2FleetNode node = getNode();
         return node == null ? "removing fleet node" : node.getDisplayName();
-    }
-
-    /**
-     * Will be called when task execution finished by slave, detailed documentation
-     * {@link SlaveComputer#taskCompleted(Executor, Queue.Task, long)}
-     * <p>
-     * EC2 Fleet plugin overrides this method to detect jobs which were failed because of
-     * EC2 instance was terminated/stopped. It could be manual stop or because of Spot marked.
-     * In all cases as soon as job aborted because of broken connection and slave is offline
-     * it will try to resubmit aborted job back to the queue, so user doesn't need to do that manually
-     * and another slave could take it.
-     * <p>
-     * Implementation details
-     * <p>
-     * There is no official recommendation about way how to resubmit job according to
-     * https://issues.jenkins-ci.org/browse/JENKINS-49707 moreover some of Jenkins code says it impossible.
-     * <p>
-     * method checks {@link SlaveComputer#getOfflineCause()} for disconnect because of EC2 instance termination
-     * it returns
-     * <code>
-     * result = {OfflineCause$ChannelTermination@13708} "Connection was broken: java.io.IOException:
-     * Unexpected termination of the channel\n\tat hudson.remoting.SynchronousCommandTransport$ReaderThread...
-     * cause = {IOException@13721} "java.io.IOException: Unexpected termination of the channel"
-     * timestamp = 1561067177837
-     * </code>
-     *
-     * @param executor   executor
-     * @param task       task
-     * @param durationMS duration
-     */
-    @Override
-    public void taskCompleted(final Executor executor, final Queue.Task task, final long durationMS) {
-        super.taskCompleted(executor, task, durationMS);
-        if (isOffline() && getOfflineCause() instanceof OfflineCause.ChannelTermination) {
-            LOGGER.info(" job " + task.getName() + " on " + getDisplayName() + " execution aborted because of slave EC2 instance was terminated, resubmitting");
-            Queue.getInstance().schedule(task, RESCHEDULE_QUIET_PERIOD_SEC);
-        }
     }
 
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2TerminationCause.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2TerminationCause.java
@@ -1,0 +1,39 @@
+package com.amazon.jenkins.ec2fleet;
+
+import jenkins.model.CauseOfInterruption;
+
+import javax.annotation.Nonnull;
+
+public class EC2TerminationCause extends CauseOfInterruption {
+
+    @Nonnull
+    private final String nodeName;
+
+    @SuppressWarnings("WeakerAccess")
+    public EC2TerminationCause(@Nonnull String nodeName) {
+        this.nodeName = nodeName;
+    }
+
+    @Override
+    public String getShortDescription() {
+        return "EC2 instance for node " + nodeName + " was terminated";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        EC2TerminationCause that = (EC2TerminationCause) o;
+        return nodeName.equals(that.nodeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return nodeName.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getShortDescription();
+    }
+
+}

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -86,6 +86,11 @@
     <f:entry title="${%Only running instances}" field="addNodeOnlyIfRunning">
       <f:checkbox />
     </f:entry>
+
+    <f:description>Disable auto resubmit build if failed because of EC2 instance termination like Spot</f:description>
+    <f:entry title="${%Disable build resubmit}" field="disableTaskResubmit">
+      <f:checkbox />
+    </f:entry>
   </f:section>
 
 </j:jelly>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-disableTaskResubmit.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-disableTaskResubmit.html
@@ -1,0 +1,22 @@
+If unchecked which is default, plugin will try to resubmit job if it was failed due to
+<a href="https://aws.amazon.com/ec2/spot/">EC2 Spot instance</a> interruption. If checked auto resubmit
+will be disabled.
+
+<p>
+    Interrupted job will be shown as failed or aborted see pipeline notes below.
+    While copy will be submitted into jenkins queue to execute or any possible node.
+</p>
+
+<p>
+    Parametrized job will be resubmitted with same parameters as defined for interrupted.
+</p>
+
+<p>
+    In case if job is <a href="https://jenkins.io/doc/book/pipeline/">pipeline (workflow)</a> interrupted
+    task will be aborted as workflow usually don't fail in case of node interruption and wait until
+    node will be online. Plugin force job to abort and resubmit.
+</p>
+
+<p>
+    Please report any problem with this feature to <a href="https://github.com/jenkinsci/ec2-fleet-plugin/issues/45">GitHub Issue</a>
+</p>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -160,7 +160,7 @@ public class AutoResubmitIntegrationTest {
             build = null
             run = {FreeStyleBuild@14834} "parameter #14"
          */
-        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("sleep ${number}") : new Shell("sleep ${number}"));
+        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("pause ${number}") : new Shell("sleep ${number}"));
 
         rs.add(project.scheduleBuild2(0, new ParametersAction(new StringParameterValue("number", "30"))));
 
@@ -306,13 +306,12 @@ public class AutoResubmitIntegrationTest {
 
     private List<QueueTaskFuture> getQueueTaskFutures(int count) throws IOException {
         final LabelAtom label = new LabelAtom("momo");
-        final String command = "sleep 30";
 
         final List<QueueTaskFuture> rs = new ArrayList<>();
         for (int i = 0; i < count; i++) {
             final FreeStyleProject project = j.createFreeStyleProject();
             project.setAssignedLabel(label);
-            project.getBuildersList().add(Functions.isWindows() ? new BatchFile(command) : new Shell(command));
+            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("pause 30") : new Shell("sleep 30"));
             rs.add(project.scheduleBuild2(0));
         }
         return rs;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -160,7 +160,7 @@ public class AutoResubmitIntegrationTest {
             build = null
             run = {FreeStyleBuild@14834} "parameter #14"
          */
-        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("pause ${number}") : new Shell("sleep ${number}"));
+        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T ${number} /NOBREAK") : new Shell("sleep ${number}"));
 
         rs.add(project.scheduleBuild2(0, new ParametersAction(new StringParameterValue("number", "30"))));
 
@@ -311,7 +311,7 @@ public class AutoResubmitIntegrationTest {
         for (int i = 0; i < count; i++) {
             final FreeStyleProject project = j.createFreeStyleProject();
             project.setAssignedLabel(label);
-            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("pause 30") : new Shell("sleep 30"));
+            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T 30 /NOBREAK") : new Shell("sleep 30"));
             rs.add(project.scheduleBuild2(0));
         }
         return rs;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -160,7 +160,7 @@ public class AutoResubmitIntegrationTest {
             build = null
             run = {FreeStyleBuild@14834} "parameter #14"
          */
-        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T ${number} /NOBREAK") : new Shell("sleep ${number}"));
+        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T %number% /NOBREAK > NUL") : new Shell("sleep ${number}"));
 
         rs.add(project.scheduleBuild2(0, new ParametersAction(new StringParameterValue("number", "30"))));
 
@@ -311,7 +311,7 @@ public class AutoResubmitIntegrationTest {
         for (int i = 0; i < count; i++) {
             final FreeStyleProject project = j.createFreeStyleProject();
             project.setAssignedLabel(label);
-            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T 30 /NOBREAK") : new Shell("sleep 30"));
+            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T 30 /NOBREAK > NUL") : new Shell("sleep 30"));
             rs.add(project.scheduleBuild2(0));
         }
         return rs;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -160,7 +160,7 @@ public class AutoResubmitIntegrationTest {
             build = null
             run = {FreeStyleBuild@14834} "parameter #14"
          */
-        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T %number% /NOBREAK > NUL") : new Shell("sleep ${number}"));
+        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("Ping -n %number% 127.0.0.1 > nul") : new Shell("sleep ${number}"));
 
         rs.add(project.scheduleBuild2(0, new ParametersAction(new StringParameterValue("number", "30"))));
 
@@ -311,7 +311,7 @@ public class AutoResubmitIntegrationTest {
         for (int i = 0; i < count; i++) {
             final FreeStyleProject project = j.createFreeStyleProject();
             project.setAssignedLabel(label);
-            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("timeout /T 30 /NOBREAK > NUL") : new Shell("sleep 30"));
+            project.getBuildersList().add(Functions.isWindows() ? new BatchFile("Ping -n 30 127.0.0.1 > nul") : new Shell("sleep 30"));
             rs.add(project.scheduleBuild2(0));
         }
         return rs;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -1,0 +1,339 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.ActiveInstance;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesResult;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsResult;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
+import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
+import hudson.Functions;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Node;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.StringParameterDefinition;
+import hudson.model.StringParameterValue;
+import hudson.model.TaskListener;
+import hudson.model.labels.LabelAtom;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.slaves.ComputerConnector;
+import hudson.slaves.ComputerLauncher;
+import hudson.slaves.OfflineCause;
+import hudson.tasks.BatchFile;
+import hudson.tasks.Shell;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.mockito.Mockito;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AutoResubmitIntegrationTest {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @ClassRule
+    public static BuildWatcher bw = new BuildWatcher();
+
+    @Before
+    public void before() {
+        EC2Api ec2Api = mock(EC2Api.class);
+        Registry.setEc2Api(ec2Api);
+
+        AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
+        when(ec2Api.connect(anyString(), anyString(), Mockito.nullable(String.class))).thenReturn(amazonEC2);
+
+        when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class))).thenReturn(
+                new DescribeInstancesResult().withReservations(
+                        new Reservation().withInstances(
+                                new Instance()
+                                        .withPublicIpAddress("public-io")
+                                        .withInstanceId("i-1")
+                        )));
+
+        when(amazonEC2.describeSpotFleetInstances(any(DescribeSpotFleetInstancesRequest.class)))
+                .thenReturn(new DescribeSpotFleetInstancesResult()
+                        .withActiveInstances(new ActiveInstance().withInstanceId("i-1")));
+
+        DescribeSpotFleetRequestsResult describeSpotFleetRequestsResult = new DescribeSpotFleetRequestsResult();
+        describeSpotFleetRequestsResult.setSpotFleetRequestConfigs(Arrays.asList(
+                new SpotFleetRequestConfig()
+                        .withSpotFleetRequestState("active")
+                        .withSpotFleetRequestConfig(
+                                new SpotFleetRequestConfigData().withTargetCapacity(1))));
+        when(amazonEC2.describeSpotFleetRequests(any(DescribeSpotFleetRequestsRequest.class)))
+                .thenReturn(describeSpotFleetRequestsResult);
+    }
+
+    @After
+    public void after() {
+        // restore
+        Registry.setEc2Api(new EC2Api());
+    }
+
+    @Test
+    public void should_successfully_resubmit_freestyle_task() throws Exception {
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, new SingleComputerConnector(j), false, false,
+                0, 0, 10, 1, false, false, false);
+        j.jenkins.clouds.add(cloud);
+
+        List<QueueTaskFuture> rs = getQueueTaskFutures(1);
+
+        System.out.println("check if zero nodes!");
+        Assert.assertEquals(0, j.jenkins.getNodes().size());
+
+        assertAtLeastOneNode();
+
+        final Node node = j.jenkins.getNodes().get(0);
+        assertQueueIsEmpty();
+
+        System.out.println("disconnect node");
+        node.toComputer().disconnect(new OfflineCause.ChannelTermination(new UnsupportedOperationException("Test")));
+
+        // due to test nature job could be failed if started or aborted as we call disconnect
+        // in prod code it's not matter
+        assertLastBuildResult(Result.FAILURE, Result.ABORTED);
+
+        node.toComputer().connect(true);
+        assertNodeIsOnline(node);
+        assertQueueAndNodesIdle(node);
+
+        Assert.assertEquals(1, j.jenkins.getProjects().size());
+        Assert.assertEquals(Result.SUCCESS, j.jenkins.getProjects().get(0).getLastBuild().getResult());
+        Assert.assertEquals(2, j.jenkins.getProjects().get(0).getBuilds().size());
+
+        cancelTasks(rs);
+    }
+
+    @Test
+    public void should_successfully_resubmit_parametrized_task() throws Exception {
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, new SingleComputerConnector(j), false, false,
+                0, 0, 10, 1, false, false, false);
+        j.jenkins.clouds.add(cloud);
+
+        List<QueueTaskFuture> rs = new ArrayList<>();
+        final FreeStyleProject project = j.createFreeStyleProject();
+        project.setAssignedLabel(new LabelAtom("momo"));
+        project.addProperty(new ParametersDefinitionProperty(new StringParameterDefinition("number", "opa")));
+        /*
+        example of actions for project
+
+        actions = {CopyOnWriteArrayList@14845}  size = 2
+            0 = {ParametersAction@14853}
+            safeParameters = {TreeSet@14855}  size = 0
+            parameters = {ArrayList@14856}  size = 1
+            0 = {StringParameterValue@14862} "(StringParameterValue) number='1'"
+            value = "1"
+            name = "number"
+            description = ""
+            parameterDefinitionNames = {ArrayList@14857}  size = 1
+            0 = "number"
+            build = null
+            run = {FreeStyleBuild@14834} "parameter #14"
+         */
+        project.getBuildersList().add(Functions.isWindows() ? new BatchFile("sleep ${number}") : new Shell("sleep ${number}"));
+
+        rs.add(project.scheduleBuild2(0, new ParametersAction(new StringParameterValue("number", "30"))));
+
+        System.out.println("check if zero nodes!");
+        Assert.assertEquals(0, j.jenkins.getNodes().size());
+
+        assertAtLeastOneNode();
+
+        final Node node = j.jenkins.getNodes().get(0);
+        assertQueueIsEmpty();
+
+        System.out.println("disconnect node");
+        node.toComputer().disconnect(new OfflineCause.ChannelTermination(new UnsupportedOperationException("Test")));
+
+        assertLastBuildResult(Result.FAILURE, Result.ABORTED);
+
+        node.toComputer().connect(true);
+        assertNodeIsOnline(node);
+        assertQueueAndNodesIdle(node);
+
+        Assert.assertEquals(1, j.jenkins.getProjects().size());
+        Assert.assertEquals(Result.SUCCESS, j.jenkins.getProjects().get(0).getLastBuild().getResult());
+        Assert.assertEquals(2, j.jenkins.getProjects().get(0).getBuilds().size());
+
+        cancelTasks(rs);
+    }
+
+    @Test
+    public void should_not_resubmit_if_disabled() throws Exception {
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
+                null, "fId", "momo", null, new SingleComputerConnector(j), false, false,
+                0, 0, 10, 1, false, false, true);
+        j.jenkins.clouds.add(cloud);
+
+        List<QueueTaskFuture> rs = getQueueTaskFutures(1);
+
+        System.out.println("check if zero nodes!");
+        Assert.assertEquals(0, j.jenkins.getNodes().size());
+
+        assertAtLeastOneNode();
+
+        final Node node = j.jenkins.getNodes().get(0);
+        assertQueueIsEmpty();
+
+        System.out.println("disconnect node");
+        node.toComputer().disconnect(new OfflineCause.ChannelTermination(new UnsupportedOperationException("Test")));
+
+        assertLastBuildResult(Result.FAILURE, Result.ABORTED);
+
+        node.toComputer().connect(true);
+        assertNodeIsOnline(node);
+        assertQueueAndNodesIdle(node);
+
+        Assert.assertEquals(1, j.jenkins.getProjects().size());
+        Assert.assertEquals(Result.FAILURE, j.jenkins.getProjects().get(0).getLastBuild().getResult());
+        Assert.assertEquals(1, j.jenkins.getProjects().get(0).getBuilds().size());
+
+        cancelTasks(rs);
+    }
+
+    private static void assertQueueAndNodesIdle(final Node node) {
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                Assert.assertTrue(Queue.getInstance().isEmpty() && node.toComputer().isIdle());
+            }
+        });
+    }
+
+    private static void assertQueueIsEmpty() {
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("check if queue is empty");
+                Assert.assertTrue(Queue.getInstance().isEmpty());
+            }
+        });
+    }
+
+    private void assertAtLeastOneNode() {
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("check if non zero nodes!");
+                Assert.assertFalse(j.jenkins.getNodes().isEmpty());
+            }
+        });
+    }
+
+    private void assertLastBuildResult(final Result... lastBuildResults) {
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                final AbstractBuild lastBuild = j.jenkins.getProjects().get(0).getLastBuild();
+                System.out.println("wait until " + Arrays.toString(lastBuildResults) + " current state "
+                        + (lastBuild == null ? "<none>" : lastBuild.getResult()));
+                Assert.assertNotNull(lastBuild);
+                Assert.assertTrue(
+                        lastBuild.getResult() + " should be in " + Arrays.toString(lastBuildResults),
+                        Arrays.asList(lastBuildResults).contains(lastBuild.getResult()));
+            }
+        });
+    }
+
+    private void assertNodeIsOnline(final Node node) {
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                System.out.println("wait when back online");
+                Assert.assertTrue(node.toComputer().isOnline());
+            }
+        });
+    }
+
+    private static void tryUntil(Runnable r) {
+        long d = TimeUnit.SECONDS.toMillis(5);
+        long time = TimeUnit.SECONDS.toMillis(60);
+        final long start = System.currentTimeMillis();
+
+        while (true) {
+            try {
+                r.run();
+                return;
+            } catch (AssertionError e) {
+                if (System.currentTimeMillis() - start > time) {
+                    throw e;
+                } else {
+                    try {
+                        Thread.sleep(d);
+                    } catch (InterruptedException ex) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+    }
+
+    private void cancelTasks(List<QueueTaskFuture> rs) {
+        for (QueueTaskFuture r : rs) {
+            r.cancel(true);
+        }
+    }
+
+    private List<QueueTaskFuture> getQueueTaskFutures(int count) throws IOException {
+        final LabelAtom label = new LabelAtom("momo");
+        final String command = "sleep 30";
+
+        final List<QueueTaskFuture> rs = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            final FreeStyleProject project = j.createFreeStyleProject();
+            project.setAssignedLabel(label);
+            project.getBuildersList().add(Functions.isWindows() ? new BatchFile(command) : new Shell(command));
+            rs.add(project.scheduleBuild2(0));
+        }
+        return rs;
+    }
+
+    private static class SingleComputerConnector extends ComputerConnector implements Serializable {
+
+        @Nonnull
+        private transient final JenkinsRule j;
+
+        private SingleComputerConnector(final JenkinsRule j) {
+            this.j = j;
+        }
+
+        @Override
+        public ComputerLauncher launch(@Nonnull String host, TaskListener listener) throws IOException {
+            try {
+                return j.createComputerLauncher(null);
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -1,0 +1,169 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.model.Action;
+import hudson.model.Actionable;
+import hudson.model.Executor;
+import hudson.model.Queue;
+import hudson.model.Result;
+import hudson.model.Slave;
+import hudson.model.queue.SubTask;
+import hudson.slaves.OfflineCause;
+import hudson.slaves.SlaveComputer;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, Queue.class})
+public class EC2FleetAutoResubmitComputerLauncherTest {
+
+    @Mock
+    private Action action1;
+
+    @Mock
+    private Executor executor1;
+
+    @Mock
+    private Executor executor2;
+
+    private Actionable executable1;
+
+    @Mock
+    private Queue.Executable executable2;
+
+    @Mock
+    private Slave slave;
+
+    @Mock
+    private SlaveComputer computer;
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Mock
+    private Queue queue;
+
+    @Mock
+    private SubTask subTask1;
+
+    @Mock
+    private SubTask subTask2;
+
+    @Mock
+    private Queue.Task task1;
+
+    @Mock
+    private Queue.Task task2;
+
+    @Mock
+    private EC2FleetNode fleetNode;
+
+    @Before
+    public void before() {
+        executable1 = mock(Actionable.class, withSettings().extraInterfaces(Queue.Executable.class));
+
+        when(computer.getDisplayName()).thenReturn("i-12");
+
+        PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Queue.getInstance()).thenReturn(queue);
+
+        when(slave.getNumExecutors()).thenReturn(1);
+
+        when(fleetNode.getDisplayName()).thenReturn("fleet node name");
+
+        when(((Queue.Executable) executable1).getParent()).thenReturn(subTask1);
+        when(executable2.getParent()).thenReturn(subTask2);
+
+        when(subTask1.getOwnerTask()).thenReturn(task1);
+        when(subTask2.getOwnerTask()).thenReturn(task2);
+
+        when(executor1.getCurrentExecutable()).thenReturn((Queue.Executable) executable1);
+        when(executor2.getCurrentExecutable()).thenReturn(executable2);
+
+        when(computer.getExecutors()).thenReturn(Arrays.asList(executor1, executor2));
+        when(computer.isOffline()).thenReturn(true);
+    }
+
+    @Test
+    public void afterDisconnect_should_do_nothing_if_task_finished_without_cause() {
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void afterDisconnect_should_do_nothing_if_task_finished_offline_but_no_cause() {
+        when(computer.isOffline()).thenReturn(true);
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void afterDisconnect_should_do_nothing_if_task_finished_cause_but_still_online() {
+        when(computer.isOffline()).thenReturn(false);
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void taskCompleted_should_resubmit_task_if_offline_and_cause_disconnect() {
+        when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verify(queue).schedule2(eq(task1), anyInt(), eq(Collections.<Action>emptyList()));
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void taskCompleted_should_resubmit_task_for_all_executors() {
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verify(queue).schedule2(eq(task1), anyInt(), eq(Collections.<Action>emptyList()));
+        verify(queue).schedule2(eq(task2), anyInt(), eq(Collections.<Action>emptyList()));
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void taskCompleted_should_abort_executors_during_resubmit() {
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verify(executor1).interrupt(Result.ABORTED, new EC2TerminationCause("i-12"));
+        verify(executor2).interrupt(Result.ABORTED, new EC2TerminationCause("i-12"));
+    }
+
+    @Test
+    public void taskCompleted_should_resubmit_task_with_actions() {
+        when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
+        when(executable1.getActions()).thenReturn(Arrays.asList(action1));
+        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        new EC2FleetAutoResubmitComputerLauncher(null, false)
+                .afterDisconnect(computer, null);
+        verify(queue).schedule2(eq(task1), anyInt(), eq(Arrays.asList(action1)));
+        verifyZeroInteractions(queue);
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -119,7 +119,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "", null, null, null, null, false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         // when
         Collection<NodeProvisioner.PlannedNode> r = fleetCloud.provision(null, 1);
@@ -149,7 +149,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "", "fleetId", null, null, null, false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         // when
         FleetStateStats stats = fleetCloud.updateStatus();
@@ -206,7 +206,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "", "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false, false);
+                false, 0, 0, 1, 1, false, false, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -270,7 +270,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, "credId", null, "region",
                 "", "fleetId", null, null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false, true);
+                false, 0, 0, 1, 1, false, true, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -484,7 +484,7 @@ public class EC2FleetCloudTest {
                 null, null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
     }
 
@@ -494,7 +494,7 @@ public class EC2FleetCloudTest {
                 "CloudName", null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
     }
 
@@ -504,7 +504,7 @@ public class EC2FleetCloudTest {
                 null, null, null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         Assert.assertNull(ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -514,7 +514,7 @@ public class EC2FleetCloudTest {
                 null, null, "Opa", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -524,7 +524,7 @@ public class EC2FleetCloudTest {
                 null, "Opa", null, null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -534,7 +534,7 @@ public class EC2FleetCloudTest {
                 null, "A", "B", null, null, null,
                 null, null, null, false,
                 false, null, null, null,
-                null, false, false);
+                null, false, false, false);
         assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
@@ -2,7 +2,6 @@ package com.amazon.jenkins.ec2fleet;
 
 import hudson.model.Queue;
 import hudson.model.Slave;
-import hudson.slaves.OfflineCause;
 import jenkins.model.Jenkins;
 import org.junit.Assert;
 import org.junit.Before;
@@ -13,17 +12,12 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Jenkins.class, Queue.class})
+@PrepareForTest({Jenkins.class})
 public class EC2FleetNodeComputerTest {
 
     @Mock
@@ -34,9 +28,6 @@ public class EC2FleetNodeComputerTest {
 
     @Mock
     private Queue queue;
-
-    @Mock
-    private Queue.Task task;
 
     @Mock
     private EC2FleetNode fleetNode;
@@ -64,39 +55,6 @@ public class EC2FleetNodeComputerTest {
         EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(slave));
         doReturn(fleetNode).when(computer).getNode();
         Assert.assertEquals("fleet node name", computer.getDisplayName());
-    }
-
-    @Test
-    public void taskCompleted_should_do_nothing_if_task_finished_without_cause() {
-        EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(slave));
-        computer.taskCompleted(null, task, 0);
-        verifyZeroInteractions(queue);
-    }
-
-    @Test
-    public void taskCompleted_should_do_nothing_if_task_finished_offline_but_no_cause() {
-        EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(slave));
-        when(computer.isOffline()).thenReturn(true);
-        computer.taskCompleted(null, task, 0);
-        verifyZeroInteractions(queue);
-    }
-
-    @Test
-    public void taskCompleted_should_do_nothing_if_task_finished_cause_but_still_online() {
-        EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(slave));
-        when(computer.isOffline()).thenReturn(false);
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
-        computer.taskCompleted(null, task, 0);
-        verifyZeroInteractions(queue);
-    }
-
-    @Test
-    public void taskCompleted_should_resubmit_task_if_offline_and_cause_disconnect() {
-        EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(slave));
-        when(computer.isOffline()).thenReturn(true);
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
-        computer.taskCompleted(null, task, 0);
-        verify(queue).schedule(eq(task), anyInt());
     }
 
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -71,7 +71,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 0, 1, false, false);
+                0, 0, 0, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -111,7 +111,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, false, false);
+                0, 0, 10, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -180,7 +180,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, false, false);
+                0, 0, 10, 1, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);
@@ -262,7 +262,7 @@ public class ProvisionIntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false);
+                0, 0, 10, 1, true, false, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = mock(EC2Api.class);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
@@ -50,7 +50,7 @@ public class RealEc2ApiIntegrationTest {
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
                 EC2FleetCloud cloud = new EC2FleetCloud("", "credId", null, null, null, fleetId,
                         null, null, null, false, false,
-                        0, 0, 0, 0, false, false);
+                        0, 0, 0, 0, false, false, false);
                 j.jenkins.clouds.add(cloud);
 
                 // 10 sec refresh time so wait
@@ -82,7 +82,7 @@ public class RealEc2ApiIntegrationTest {
             public void run(AmazonEC2 amazonEC2, String fleetId) throws Exception {
                 EC2FleetCloud cloud = new EC2FleetCloud(null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
-                        0, 0, 0, 0, false, false);
+                        0, 0, 0, 0, false, false, false);
                 j.jenkins.clouds.add(cloud);
 
                 final long start = System.currentTimeMillis();

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -44,7 +44,7 @@ public class UiIntegrationTest {
     public void shouldShowInConfigurationClouds() throws IOException, SAXException {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -57,12 +57,12 @@ public class UiIntegrationTest {
     public void shouldShowMultipleClouds() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -78,12 +78,12 @@ public class UiIntegrationTest {
     public void shouldShowMultipleCloudsWithDefaultName() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -99,12 +99,12 @@ public class UiIntegrationTest {
     public void shouldUpdateProperCloudWhenMultiple() throws IOException, SAXException {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -122,12 +122,12 @@ public class UiIntegrationTest {
     public void shouldGetFirstWhenMultipleCloudWithSameName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("FleetCloud"));
@@ -137,12 +137,12 @@ public class UiIntegrationTest {
     public void shouldGetProperWhenMultipleWithDiffName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, false, false);
+                0, 0, 0, 0, false, false, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("a"));


### PR DESCRIPTION
Cover additional cases for #104 

### Done

- Parametrized jobs require schedule ```actions``` which represent actual parameter values together with the original job 
- Pipeline job doesn't fail when the node is disconnected, instead, it's waiting, so we need to abort it from the plugin as no way to reconnect node and reschedule
- Add configuration to disable auto resubmit (by default ```enabled```)

### Testing 
- Integration tests were added for freestyle job and parametrized
- Pipeline test is done manually as pipeline plugin requires Jenkins version ```>2``` while we still support Jenkins ```1.x```