### PR TITLE
Reduce amount of describeInstances calls for fleet update

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -20,8 +20,9 @@ import org.apache.commons.lang.StringUtils;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -52,24 +53,24 @@ public class EC2Api {
         return instanceIds;
     }
 
-    public Set<String> describeTerminated(final AmazonEC2 ec2, final Set<String> instanceIds) {
-        return describeTerminated(ec2, instanceIds, BATCH_SIZE);
+    public Map<String, Instance> describeInstances(final AmazonEC2 ec2, final Set<String> instanceIds) {
+        return describeInstances(ec2, instanceIds, BATCH_SIZE);
     }
 
-    public Set<String> describeTerminated(final AmazonEC2 ec2, final Set<String> instanceIds, final int batchSize) {
-        // assume all terminated until we get opposite info
-        final Set<String> terminated = new HashSet<>(instanceIds);
+    public Map<String, Instance> describeInstances(final AmazonEC2 ec2, final Set<String> instanceIds, final int batchSize) {
+        final Map<String, Instance> described = new HashMap<>();
         // don't do actual call if no data
-        if (instanceIds.isEmpty()) return terminated;
+        if (instanceIds.isEmpty()) return described;
 
         final List<List<String>> batches = Lists.partition(new ArrayList<>(instanceIds), batchSize);
         for (final List<String> batch : batches) {
-            describeTerminatedBatch(ec2, terminated, batch);
+            describeInstancesBatch(ec2, described, batch);
         }
-        return terminated;
+        return described;
     }
 
-    private static void describeTerminatedBatch(final AmazonEC2 ec2, final Set<String> terminated, final List<String> batch) {
+    private static void describeInstancesBatch(
+            final AmazonEC2 ec2, final Map<String, Instance> described, final List<String> batch) {
         // we are going to modify list, so copy
         final List<String> copy = new ArrayList<>(batch);
 
@@ -89,9 +90,9 @@ public class EC2Api {
 
                     for (final Reservation r : result.getReservations()) {
                         for (final Instance instance : r.getInstances()) {
-                            // if instance not in terminated state, remove it from terminated
+                            // if instance not in terminated state, add it to described
                             if (!TERMINATED_STATES.contains(instance.getState().getName())) {
-                                terminated.remove(instance.getInstanceId());
+                                described.put(instance.getInstanceId(), instance);
                             }
                         }
                     }
@@ -131,17 +132,17 @@ public class EC2Api {
      * it as first priority, otherwise will try to find region in {@link RegionUtils} by <code>regionName</code>
      * and use endpoint from it, if not available will generate endpoint as string and check if
      * region name looks like China <code>cn-</code> prefix.
-     *
+     * <p>
      * Implementation details
-     *
+     * <p>
      * {@link RegionUtils} is static information, and to get new region required to be updated,
      * as it's not possible too fast as you need to check new version of lib, moreover new version of lib
      * could be pointed to new version of Jenkins which is not a case for our plugin as some of installation
      * still on <code>1.6.x</code>
-     *
+     * <p>
      * For example latest AWS SDK lib depends on Jackson2 plugin which starting from version <code>2.8.7.0</code>
      * require Jenkins at least <code>2.60</code> https://plugins.jenkins.io/jackson2-api
-     *
+     * <p>
      * List of all AWS endpoints
      * https://docs.aws.amazon.com/general/latest/gr/rande.html
      *
@@ -165,5 +166,4 @@ public class EC2Api {
             return null;
         }
     }
-
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -39,25 +39,29 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings({"ArraysAsListWithZeroOrOneArgument", "deprecation"})
 public class AutoResubmitIntegrationTest extends IntegrationTest {
 
     @Before
     public void before() {
-        EC2Api ec2Api = mock(EC2Api.class);
+        EC2Api ec2Api = spy(EC2Api.class);
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
         when(ec2Api.connect(anyString(), anyString(), Mockito.nullable(String.class))).thenReturn(amazonEC2);
 
+        final Instance instance = new Instance()
+                .withState(new InstanceState().withName(InstanceStateName.Running))
+                .withPublicIpAddress("public-io")
+                .withInstanceId("i-1");
+
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class))).thenReturn(
                 new DescribeInstancesResult().withReservations(
                         new Reservation().withInstances(
-                                new Instance()
-                                        .withState(new InstanceState().withName(InstanceStateName.Running))
-                                        .withPublicIpAddress("public-io")
-                                        .withInstanceId("i-1")
+                                instance
                         )));
 
         when(amazonEC2.describeSpotFleetInstances(any(DescribeSpotFleetInstancesRequest.class)))
@@ -76,7 +80,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
 
     @Test
     public void should_successfully_resubmit_freestyle_task() throws Exception {
-        EC2FleetCloud cloud = new EC2FleetCloud(null, null,"credId", null, "region",
+        EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new SingleLocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
                 false, 0, 0, false);
@@ -112,7 +116,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
 
     @Test
     public void should_successfully_resubmit_parametrized_task() throws Exception {
-        EC2FleetCloud cloud = new EC2FleetCloud(null, null,"credId", null, "region",
+        EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new SingleLocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
                 false, 0, 0, false);
@@ -168,7 +172,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
 
     @Test
     public void should_not_resubmit_if_disabled() throws Exception {
-        EC2FleetCloud cloud = new EC2FleetCloud(null, null,"credId", null, "region",
+        EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new SingleLocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
                 true, 0, 0, false);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.google.common.collect.ImmutableMap;
-import com.google.inject.internal.guava.collect.$ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -235,7 +234,7 @@ public class EC2ApiTest {
         final Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals($ImmutableMap.of("i-3", instance3), described);
+        Assert.assertEquals(ImmutableMap.of("i-3", instance3), described);
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-1", "i-3", "i-f")));
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-3")));
         verifyNoMoreInteractions(amazonEC2);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -1,8 +1,6 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.AmazonEC2Exception;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
@@ -10,8 +8,9 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.internal.guava.collect.$ImmutableMap;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -20,6 +19,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.Mockito.any;
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 @RunWith(MockitoJUnitRunner.class)
 public class EC2ApiTest {
 
@@ -36,15 +37,15 @@ public class EC2ApiTest {
     private AmazonEC2 amazonEC2;
 
     @Test
-    public void shouldReturnEmptyResultAndNoCallIfEmptyListOfInstances() {
-        Set<String> terminated = new EC2Api().describeTerminated(amazonEC2, Collections.<String>emptySet());
+    public void describeInstances_shouldReturnEmptyResultAndNoCallIfEmptyListOfInstances() {
+        Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, Collections.<String>emptySet());
 
-        Assert.assertEquals(Collections.emptySet(), terminated);
+        Assert.assertEquals(Collections.<String, Instance>emptyMap(), described);
         verifyZeroInteractions(amazonEC2);
     }
 
     @Test
-    public void shouldReturnEmptyIfAllInstancesStillActive() {
+    public void describeInstances_shouldReturnAllInstancesIfStillActive() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("i-1");
@@ -64,36 +65,38 @@ public class EC2ApiTest {
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class))).thenReturn(describeInstancesResult);
 
         // when
-        Set<String> terminated = new EC2Api().describeTerminated(amazonEC2, instanceIds);
+        Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(Collections.emptySet(), terminated);
+        Assert.assertEquals(ImmutableMap.of("i-1", instance1, "i-2", instance2), described);
         verify(amazonEC2, times(1))
                 .describeInstances(any(DescribeInstancesRequest.class));
     }
 
     @Test
-    public void shouldProcessAllPagesUntilNextTokenIsAvailable() {
+    public void describeInstances_shouldProcessAllPagesUntilNextTokenIsAvailable() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("i-1");
         instanceIds.add("i-2");
         instanceIds.add("i-3");
 
+        final Instance instance1 = new Instance()
+                .withInstanceId("i-1")
+                .withState(new InstanceState().withName(InstanceStateName.Running));
         DescribeInstancesResult describeInstancesResult1 =
                 new DescribeInstancesResult()
                         .withReservations(
-                                new Reservation().withInstances(new Instance()
-                                        .withInstanceId("i-1")
-                                        .withState(new InstanceState().withName(InstanceStateName.Running))))
+                                new Reservation().withInstances(instance1))
                         .withNextToken("a");
 
+        final Instance instance2 = new Instance()
+                .withInstanceId("i-2")
+                .withState(new InstanceState().withName(InstanceStateName.Running));
         DescribeInstancesResult describeInstancesResult2 =
                 new DescribeInstancesResult()
                         .withReservations(new Reservation().withInstances(
-                                new Instance()
-                                        .withInstanceId("i-2")
-                                        .withState(new InstanceState().withName(InstanceStateName.Running)),
+                                instance2,
                                 new Instance()
                                         .withInstanceId("i-3")
                                         .withState(new InstanceState().withName(InstanceStateName.Terminated))
@@ -104,16 +107,16 @@ public class EC2ApiTest {
                 .thenReturn(describeInstancesResult2);
 
         // when
-        Set<String> terminated = new EC2Api().describeTerminated(amazonEC2, instanceIds);
+        Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(new HashSet<>(Arrays.asList("i-3")), terminated);
+        Assert.assertEquals(ImmutableMap.of("i-1", instance1, "i-2", instance2), described);
         verify(amazonEC2, times(2))
                 .describeInstances(any(DescribeInstancesRequest.class));
     }
 
     @Test
-    public void shouldAssumeMissedInResultInstanceOrTerminatedOrStoppedOrStoppingOrShuttingDownAsTermianted() {
+    public void describeInstances_shouldNotDescribeMissedInResultInstanceOrTerminatedOrStoppedOrStoppingOrShuttingDownAs() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("missed");
@@ -144,17 +147,16 @@ public class EC2ApiTest {
                 .thenReturn(describeInstancesResult1);
 
         // when
-        Set<String> terminated = new EC2Api().describeTerminated(amazonEC2, instanceIds);
+        Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(new HashSet<>(Arrays.asList(
-                "missed", "terminated", "stopped", "shutting-down", "stopping")), terminated);
+        Assert.assertEquals(Collections.<String, Instance>emptyMap(), described);
         verify(amazonEC2, times(1))
                 .describeInstances(any(DescribeInstancesRequest.class));
     }
 
     @Test
-    public void shouldSendInOneCallNoMoreThenBatchSizeOfInstance() {
+    public void describeInstances_shouldSendInOneCallNoMoreThenBatchSizeOfInstance() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("i1");
@@ -179,7 +181,7 @@ public class EC2ApiTest {
                 .thenReturn(describeInstancesResult2);
 
         // when
-        new EC2Api().describeTerminated(amazonEC2, instanceIds, 2);
+        new EC2Api().describeInstances(amazonEC2, instanceIds, 2);
 
         // then
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i1", "i2")));
@@ -208,7 +210,7 @@ public class EC2ApiTest {
      * </code>
      */
     @Test
-    public void shouldHandleAmazonEc2NotFoundErrorAsTerminatedInstancesAndRetry() {
+    public void describeInstances_shouldHandleAmazonEc2NotFoundErrorAsTerminatedInstancesAndRetry() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("i-1");
@@ -219,27 +221,28 @@ public class EC2ApiTest {
                 "The instance IDs 'i-1, i-f' do not exist");
         notFoundException.setErrorCode("InvalidInstanceID.NotFound");
 
+        final Instance instance3 = new Instance().withInstanceId("i-3")
+                .withState(new InstanceState().withName(InstanceStateName.Running));
         DescribeInstancesResult describeInstancesResult2 = new DescribeInstancesResult()
                 .withReservations(new Reservation().withInstances(
-                        new Instance().withInstanceId("i-3")
-                                .withState(new InstanceState().withName(InstanceStateName.Running))));
+                        instance3));
 
         when(amazonEC2.describeInstances(any(DescribeInstancesRequest.class)))
                 .thenThrow(notFoundException)
                 .thenReturn(describeInstancesResult2);
 
         // when
-        final Set<String> terminatedIds = new EC2Api().describeTerminated(amazonEC2, instanceIds);
+        final Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(new HashSet<>(Arrays.asList("i-1", "i-f")), terminatedIds);
+        Assert.assertEquals($ImmutableMap.of("i-3", instance3), described);
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-1", "i-3", "i-f")));
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-3")));
         verifyNoMoreInteractions(amazonEC2);
     }
 
     @Test
-    public void shouldFailIfNotAbleToParseNotFoundExceptionFromEc2Api() {
+    public void describeInstances_shouldFailIfNotAbleToParseNotFoundExceptionFromEc2Api() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("i-1");
@@ -255,7 +258,7 @@ public class EC2ApiTest {
 
         // when
         try {
-            new EC2Api().describeTerminated(amazonEC2, instanceIds);
+            new EC2Api().describeInstances(amazonEC2, instanceIds);
             Assert.fail();
         } catch (AmazonEC2Exception exception) {
             Assert.assertSame(notFoundException, exception);
@@ -263,7 +266,7 @@ public class EC2ApiTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfEc2DescribeFailsWithException() {
+    public void describeInstances_shouldThrowExceptionIfEc2DescribeFailsWithException() {
         // given
         Set<String> instanceIds = new HashSet<>();
         instanceIds.add("a");
@@ -274,29 +277,11 @@ public class EC2ApiTest {
 
         // when
         try {
-            new EC2Api().describeTerminated(amazonEC2, instanceIds);
+            new EC2Api().describeInstances(amazonEC2, instanceIds);
             Assert.fail();
         } catch (UnsupportedOperationException e) {
             Assert.assertSame(exception, e);
         }
-    }
-
-    @Ignore("manual test pass credentials if you want to run")
-    @Test
-    public void realShouldHandleAmazonEc2NotFoundErrorAsTerminatedInstancesAndRetry() {
-        // given
-        final String accessKey = "...";
-        final String secretKey = "...";
-
-        final Set<String> instanceIds = new HashSet<>();
-        instanceIds.add("i-1233f");
-        instanceIds.add("i-ff");
-
-        final AmazonEC2 amazonEC2 = new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey));
-
-        // when
-        Set<String> t = new EC2Api().describeTerminated(amazonEC2, instanceIds);
-        Assert.assertEquals(instanceIds, t);
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -50,6 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -185,7 +186,7 @@ public abstract class IntegrationTest {
     }
 
     protected void mockEc2ApiToDescribeInstancesWhenModified(final InstanceStateName instanceStateName) {
-        EC2Api ec2Api = mock(EC2Api.class);
+        EC2Api ec2Api = spy(EC2Api.class);
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -52,7 +52,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                 false, 0, 0, false);
         j.jenkins.clouds.add(cloud);
 
-        EC2Api ec2Api = mock(EC2Api.class);
+        EC2Api ec2Api = spy(EC2Api.class);
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
@@ -178,7 +178,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                 false, 0, 0, false));
         j.jenkins.clouds.add(cloud);
 
-        EC2Api ec2Api = mock(EC2Api.class);
+        EC2Api ec2Api = spy(EC2Api.class);
         Registry.setEc2Api(ec2Api);
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);


### PR DESCRIPTION
During start-up for new instances plugin does ```describeInstances``` calls to get their IP address, one per instance

- Each ```10 sec``` plugin does a few calls
  - fleet describe by calling ```describeSpotRequest```
  - ```describeInstances``` to find if any instances are terminated (batch call)
  - ```describeInstances``` per new instance

This fix eliminate last ```describeInstances``` call by reusing data from previous one, so each ```10 sec``` plugin does no more then ```2 calls```

This should help to avoid ```LimitExceedException``` for accounts with small limit call to EC2 or for small regions, which could have small limit.