### PR TITLE
add: use getNumActive when determining new target weight

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -318,11 +318,11 @@ public class EC2FleetCloud extends Cloud {
         // Calculate the ceiling, without having to work with doubles from Math.ceil
         // https://stackoverflow.com/a/21830188/877024
         final int weightedExcessWorkload = (excessWorkload + numExecutors - 1) / numExecutors;
-        int targetCapacity = stats.getNumDesired() + weightedExcessWorkload;
+        int targetCapacity = stats.getNumActive() + weightedExcessWorkload;
 
         if (targetCapacity > maxAllowed) targetCapacity = maxAllowed;
 
-        int toProvision = targetCapacity - stats.getNumDesired();
+        int toProvision = targetCapacity - stats.getNumActive();
         info("to provision = %s", toProvision);
 
         if (toProvision < 1)


### PR DESCRIPTION
In the case where the swarm is over provisioned, i.e. target = 1, capacity = 2, excess workload would only increase the workload to 2 if a new job arrived which would not cause a new node to be provisioned.  This changes uses the current capacity when determining the next capacity so that in this specific case, target would be increased >2 which would then cause new nodes to be created.

Addresses comment in https://github.com/jenkinsci/ec2-fleet-plugin/issues/125#issuecomment-526465401 