### PR TITLE
Make cloud status check interval configurable.

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -61,6 +61,8 @@ public class EC2FleetCloud extends Cloud {
 
     public static final String FLEET_CLOUD_ID = "FleetCloud";
 
+    public static final int DEFAULT_CLOUD_STATUS_INTERVAL_SEC = 10;
+
     private static final int DEFAULT_INIT_ONLINE_TIMEOUT_SEC = 3 * 60;
     private static final int DEFAULT_INIT_ONLINE_CHECK_INTERVAL_SEC = 15;
 
@@ -122,6 +124,7 @@ public class EC2FleetCloud extends Cloud {
     private final boolean scaleExecutorsByWeight;
     private final Integer initOnlineTimeoutSec;
     private final Integer initOnlineCheckIntervalSec;
+    private final Integer cloudStatusIntervalSec;
 
     /**
      * @see EC2FleetAutoResubmitComputerLauncher
@@ -168,7 +171,8 @@ public class EC2FleetCloud extends Cloud {
                          final boolean disableTaskResubmit,
                          final Integer initOnlineTimeoutSec,
                          final Integer initOnlineCheckIntervalSec,
-                         final boolean scaleExecutorsByWeight) {
+                         final boolean scaleExecutorsByWeight,
+                         final Integer cloudStatusIntervalSec) {
         super(StringUtils.isBlank(name) ? FLEET_CLOUD_ID : name);
         init();
         this.credentialsId = credentialsId;
@@ -191,6 +195,7 @@ public class EC2FleetCloud extends Cloud {
         this.disableTaskResubmit = disableTaskResubmit;
         this.initOnlineTimeoutSec = initOnlineTimeoutSec;
         this.initOnlineCheckIntervalSec = initOnlineCheckIntervalSec;
+        this.cloudStatusIntervalSec = cloudStatusIntervalSec;
 
         if (StringUtils.isNotEmpty(oldId)) {
             // existent cloud was modified, let's re-assign all dependencies of old cloud instance
@@ -225,6 +230,10 @@ public class EC2FleetCloud extends Cloud {
 
     public int getInitOnlineTimeoutSec() {
         return initOnlineTimeoutSec == null ? DEFAULT_INIT_ONLINE_TIMEOUT_SEC : initOnlineTimeoutSec;
+    }
+
+    public int getCloudStatusIntervalSec() {
+        return cloudStatusIntervalSec == null ? DEFAULT_CLOUD_STATUS_INTERVAL_SEC : cloudStatusIntervalSec;
     }
 
     public int getInitOnlineCheckIntervalSec() {

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -105,6 +105,11 @@
     <f:entry title="${%Maximum Init Connection Timeout in sec}" field="initOnlineTimeoutSec">
       <f:number clazz="required positive-number" default="180" />
     </f:entry>
+
+    <f:description>Interval for updating EC2 cloud status</f:description>
+    <f:entry title="${%Cloud Status Interval in sec}" field="cloudStatusIntervalSec">
+      <f:number clazz="required positive-number" default="10" />
+    </f:entry>
   </f:section>
 
 </j:jelly>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-cloudStatusIntervalSec.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-cloudStatusIntervalSec.html
@@ -1,0 +1,3 @@
+<div>
+    Set the interval for checking the status of the EC2 cloud.
+</div>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-cloudStatusIntervalSec.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-cloudStatusIntervalSec.html
@@ -1,3 +1,12 @@
 <div>
-    Set the interval for checking the status of the EC2 cloud.
+    Set the interval for checking the EC2 clouds status.
+    <p>
+        Every check fetches the current state of the cloud from EC2 and scales the size of the cloud up or down.
+    </p>
+    <p>
+        Longer intervals will reduce the number of EC2 API calls, shorter intervals will allow the cloud to faster scale up and down.
+    </p>
+    <p>
+        <b>The default is to check every 10 seconds.</b>
+    </p>
 </div>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -83,7 +83,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);
@@ -119,7 +119,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = new ArrayList<>();
@@ -175,7 +175,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                true, 0, 0, false);
+                true, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
@@ -22,8 +22,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
@@ -207,9 +209,9 @@ public class CloudNannyTest {
         cloudNanny.doRun();
 
         verify(cloud1).update();
-        verify(cloud1).getCloudStatusIntervalSec();
+        verify(cloud1, atLeastOnce()).getCloudStatusIntervalSec();
         verify(cloud2).update();
-        verify(cloud2).getCloudStatusIntervalSec();
+        verify(cloud2, atLeastOnce()).getCloudStatusIntervalSec();
 
 
         assertEquals(cloud1.getCloudStatusIntervalSec(), recurrenceCounter1.get());
@@ -226,7 +228,9 @@ public class CloudNannyTest {
 
         cloudNanny.doRun();
 
-        verifyZeroInteractions(cloud1, cloud2);
+        verify(cloud1, atLeastOnce()).getCloudStatusIntervalSec();
+        verify(cloud2, atLeastOnce()).getCloudStatusIntervalSec();
+        verifyNoMoreInteractions(cloud1, cloud2);
 
         assertEquals(1, recurrenceCounter1.get());
         assertEquals(2, recurrenceCounter2.get());
@@ -242,10 +246,11 @@ public class CloudNannyTest {
 
         cloudNanny.doRun();
 
-        verify(cloud2).getCloudStatusIntervalSec();
+        verify(cloud2, atLeastOnce()).getCloudStatusIntervalSec();
         verify(cloud2).update();
 
-        verifyZeroInteractions(cloud1);
+        verify(cloud1, atLeastOnce()).getCloudStatusIntervalSec();
+        verifyNoMoreInteractions(cloud1);
 
         assertEquals(1, recurrenceCounter1.get());
         assertEquals(cloud2.getCloudStatusIntervalSec(), recurrenceCounter2.get());

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -131,7 +131,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 10, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -156,7 +156,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 9, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 10, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -181,7 +181,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -206,7 +206,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -231,7 +231,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -260,7 +260,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         // when
         Collection<NodeProvisioner.PlannedNode> r = fleetCloud.provision(null, 1);
@@ -282,7 +282,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
@@ -303,7 +303,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -327,7 +327,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 1, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -351,7 +351,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 2, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -376,7 +376,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 2, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -403,7 +403,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false);
+                false, false, 0, 0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 3, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -433,7 +433,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 1, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         // when
         FleetStateStats stats = fleetCloud.update();
@@ -457,7 +457,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -488,7 +488,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -522,7 +522,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -557,7 +557,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -591,7 +591,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false);
+                0, false, 10);
 
         fleetCloud.setStats(new FleetStateStats("", 4, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -634,7 +634,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1,
                 false, false, false,
-                0, 0, false);
+                0, 0, false, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -674,7 +674,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, false);
+                0, 0, false, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -717,7 +717,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, false);
+                0, 0, false, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -756,7 +756,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true);
+                0, 0, true, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -795,7 +795,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true);
+                0, 0, true, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -834,7 +834,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true);
+                0, 0, true, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -873,7 +873,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true);
+                0, 0, true, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -912,7 +912,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true);
+                0, 0, true, 10);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -1160,7 +1160,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
     }
 
@@ -1171,7 +1171,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
     }
 
@@ -1182,7 +1182,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         Assert.assertNull(ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1193,7 +1193,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1204,7 +1204,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1215,11 +1215,22 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false);
+                , 0, 0, false, 10);
         assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
     }
 
     // todo create test cases update failed to modify fleet
+
+    @Test
+    public void getCloudStatusInterval_returnCloudStatusInterval() {
+        EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
+                "CloudName", null, null, null, null, null, null,
+                null, null, null, false,
+                false, null, null, null,
+                null, false, false, false
+                , 0, 0, false, 45);
+        assertEquals(45, ec2FleetCloud.getCloudStatusIntervalSec());
+    }
 
     private void mockNodeCreatingPart() {
         when(jenkins.getNodesObject()).thenReturn(mock(Nodes.class));

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
@@ -13,8 +13,8 @@ public class EC2FleetCloudWithMeter extends EC2FleetCloud {
     public transient Meter provisionMeter = new Meter("provision");
     public transient Meter removeMeter = new Meter("remove");
 
-    public EC2FleetCloudWithMeter(String name, String oldId, String awsCredentialsId, String credentialsId, String region, String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector, boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit, Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight) {
-        super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot, computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors, addNodeOnlyIfRunning, restrictUsage, disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec, scaleExecutorsByWeight);
+    public EC2FleetCloudWithMeter(String name, String oldId, String awsCredentialsId, String credentialsId, String region, String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector, boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit, Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight, Integer cloudStatusIntervalSec) {
+        super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot, computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors, addNodeOnlyIfRunning, restrictUsage, disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec, scaleExecutorsByWeight, cloudStatusIntervalSec);
     }
 
     @Override

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -64,7 +64,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 0, 1, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 2);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = spy(EC2Api.class);
@@ -104,13 +104,13 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
 
+        mockEc2ApiToDescribeFleetNotInstanceWhenModified();
+
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 2);
         j.jenkins.clouds.add(cloud);
-
-        mockEc2ApiToDescribeFleetNotInstanceWhenModified();
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);
 
@@ -139,7 +139,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 300, 15, false));
+                false, 300, 15, false, 2));
 
         // provide init state
         cloud.setStats(new FleetStateStats("", 0, "active",
@@ -170,7 +170,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         final EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false));
+                false, 0, 0, false, 10));
         j.jenkins.clouds.add(cloud);
 
         mockEc2ApiToDescribeInstancesWhenModified(InstanceStateName.Running);
@@ -195,7 +195,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false));
+                false, 0, 0, false, 10));
 
         cloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -251,7 +251,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 2);
         j.jenkins.clouds.add(cloud);
 
         mockEc2ApiToDescribeInstancesWhenModified(InstanceStateName.Pending);
@@ -282,7 +282,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 1, 0, 5, 1, true, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         // wait while all nodes will be ok

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
@@ -42,7 +42,7 @@ public class ProvisionPerformanceTest extends IntegrationTest {
         final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 1, 0, workers, 1, true, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 2);
         j.jenkins.clouds.add(cloud);
 
         // updated plugin requires some init time to get first update

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
@@ -51,7 +51,7 @@ public class RealEc2ApiIntegrationTest {
                 EC2FleetCloud cloud = new EC2FleetCloud("", null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false,
-                        false, 0, 0, false);
+                        false, 0, 0, false, 10);
                 j.jenkins.clouds.add(cloud);
 
                 // 10 sec refresh time so wait
@@ -84,7 +84,7 @@ public class RealEc2ApiIntegrationTest {
                 EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false,
-                        false, 0, 0, false);
+                        false, 0, 0, false, 10);
                 j.jenkins.clouds.add(cloud);
 
                 final long start = System.currentTimeMillis();

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -50,7 +50,7 @@ public class UiIntegrationTest {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -63,7 +63,7 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         j.jenkins.addNode(new EC2FleetNode("node-name", "", "", 1,
@@ -80,7 +80,7 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         j.jenkins.addNode(new EC2FleetNode("mock", "", "", 1,
@@ -105,7 +105,7 @@ public class UiIntegrationTest {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -118,13 +118,13 @@ public class UiIntegrationTest {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -140,13 +140,13 @@ public class UiIntegrationTest {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -162,13 +162,13 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -187,13 +187,13 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("FleetCloud"));
@@ -204,13 +204,13 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false);
+                false, 0, 0, false, 10);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("a"));


### PR DESCRIPTION
We run a large number of build hosts and spot fleet instances in an AWS account and the
default setting of 10 seconds for the CloudNanny checker ran us into API limits with AWS.

This change allows us to set the check interval from 10 seconds to 60 seconds thus keeping
us under the API limits.

This patch adds a new configuration option in the "advanced" section of the EC2 fleet configuration which
controls the interval at which the CloudNanny checker is run.