### PR TITLE
Add No Delay Provision Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,3 +260,4 @@ sudo yum install java-1.8.0
 sudo yum remove java-1.7.0-openjdk
 java -version 
 ```
+

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -132,6 +132,11 @@ public class EC2FleetCloud extends Cloud {
     private final boolean disableTaskResubmit;
 
     /**
+     * @see NoDelayProvisionStrategy
+     */
+    private final boolean noDelayProvision;
+
+    /**
      * {@link EC2FleetCloud#update()} updating this field, this is one thread
      * related to {@link CloudNanny}. At the same time {@link IdleRetentionStrategy}
      * call {@link EC2FleetCloud#scheduleToTerminate(String)} to stop instance when it free
@@ -172,7 +177,8 @@ public class EC2FleetCloud extends Cloud {
                          final Integer initOnlineTimeoutSec,
                          final Integer initOnlineCheckIntervalSec,
                          final boolean scaleExecutorsByWeight,
-                         final Integer cloudStatusIntervalSec) {
+                         final Integer cloudStatusIntervalSec,
+                         final boolean noDelayProvision) {
         super(StringUtils.isBlank(name) ? FLEET_CLOUD_ID : name);
         init();
         this.credentialsId = credentialsId;
@@ -196,12 +202,17 @@ public class EC2FleetCloud extends Cloud {
         this.initOnlineTimeoutSec = initOnlineTimeoutSec;
         this.initOnlineCheckIntervalSec = initOnlineCheckIntervalSec;
         this.cloudStatusIntervalSec = cloudStatusIntervalSec;
+        this.noDelayProvision = noDelayProvision;
 
         if (StringUtils.isNotEmpty(oldId)) {
             // existent cloud was modified, let's re-assign all dependencies of old cloud instance
             // to new one
             EC2FleetCloudAwareUtils.reassign(oldId, this);
         }
+    }
+
+    public boolean isNoDelayProvision() {
+        return noDelayProvision;
     }
 
     /**

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -1,0 +1,77 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner;
+import jenkins.model.Jenkins;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Implementation of {@link NodeProvisioner.Strategy} which will provision a new node immediately as
+ * a task enter the queue.
+ * Now that EC2 is billed by the minute, we don't really need to wait before provisioning a new node.
+ * <p>
+ * As based we are used
+ * <a href="https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java">EC2 Jenkins Plugin</a>
+ */
+@Extension(ordinal = 100)
+public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
+
+    private static final Logger LOGGER = Logger.getLogger(NoDelayProvisionStrategy.class.getName());
+
+    @Override
+    public NodeProvisioner.StrategyDecision apply(final NodeProvisioner.StrategyState strategyState) {
+        final Label label = strategyState.getLabel();
+
+        final LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
+        final int availableCapacity =
+                snapshot.getAvailableExecutors()   // live executors
+                        + snapshot.getConnectingExecutors()  // executors present but not yet connected
+                        + strategyState.getPlannedCapacitySnapshot()     // capacity added by previous strategies from previous rounds
+                        + strategyState.getAdditionalPlannedCapacity();  // capacity added by previous strategies _this round_
+
+        int currentDemand = snapshot.getQueueLength() - availableCapacity;
+        LOGGER.log(Level.INFO, "Available capacity={0}, currentDemand={1}",
+                new Object[]{availableCapacity, currentDemand});
+
+        for (final Cloud cloud : getClouds()) {
+            if (currentDemand < 1) break;
+
+            if (!(cloud instanceof EC2FleetCloud)) continue;
+            if (!cloud.canProvision(label)) continue;
+
+            final EC2FleetCloud ec2 = (EC2FleetCloud) cloud;
+            if (!ec2.isNoDelayProvision()) continue;
+
+            final Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(label, currentDemand);
+            currentDemand -= plannedNodes.size();
+            LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
+            strategyState.recordPendingLaunches(plannedNodes);
+            LOGGER.log(Level.FINE, "After provisioning, available capacity={0}, currentDemand={1}",
+                    new Object[]{availableCapacity, currentDemand});
+        }
+
+        if (currentDemand < 1) {
+            LOGGER.log(Level.FINE, "Provisioning completed");
+            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+        } else {
+            LOGGER.log(Level.FINE, "Provisioning not complete, consulting remaining strategies");
+            return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        }
+    }
+
+    @VisibleForTesting
+    protected List<Cloud> getClouds() {
+        final Jenkins jenkins = Jenkins.getInstance();
+        return jenkins == null ? Collections.<Cloud>emptyList() : jenkins.clouds;
+    }
+
+}

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -110,6 +110,11 @@
     <f:entry title="${%Cloud Status Interval in sec}" field="cloudStatusIntervalSec">
       <f:number clazz="required positive-number" default="10" />
     </f:entry>
+
+    <f:description>Enable faster provision when queue grow</f:description>
+    <f:entry title="${%No Delay Provision Strategy}" field="noDelayProvision">
+      <f:checkbox />
+    </f:entry>
   </f:section>
 
 </j:jelly>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-noDelayProvision.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-noDelayProvision.html
@@ -1,0 +1,22 @@
+Enable no delay provision strategy.
+<p>
+    Disabled by default.
+</p>
+<p>
+    Enabling of this setting will disable default Jenkins behavior for particular cloud
+    and ask this cloud to provision new agents almost as soon as new jobs appear in queue.
+</p>
+<p>
+    When this option is disable (by default).
+    Each time when Jenkins doesn't have enough agent to execute all jobs in a queue.
+    Jenkins starts provision of new agents. Default strategy is trying to keep amount of agents
+    as small as possible. It waits a little bit until queue will not reach some limit or
+    jobs in a queue will not reach some age. As result before scheduled job will be executed you can
+    see some delay.
+</p>
+<p>
+    <b>Note</b> Enabling of this setting could increase chance of over provision, because of that
+    make sure that your <code>Max Idle Minutes Before Scaledown</code> has expected value so
+    free capacity could be scale in. While Linux capacity billing per minute, Windows capacity
+    billing per hour, so be careful with this option.
+</p>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -83,7 +83,8 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);
@@ -119,7 +120,8 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = new ArrayList<>();
@@ -175,7 +177,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
                 0, 0, 10, 1, false, false,
-                true, 0, 0, false, 10);
+                true, 0, 0, false, 10, false);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -131,7 +131,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 10, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -156,7 +157,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 9, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 10, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -181,7 +183,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -206,7 +209,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -231,7 +235,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 10, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -260,7 +265,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         // when
         Collection<NodeProvisioner.PlannedNode> r = fleetCloud.provision(null, 1);
@@ -282,7 +288,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
@@ -303,7 +310,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -327,7 +335,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 1, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -351,7 +360,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -376,7 +386,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 0, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -403,7 +414,8 @@ public class EC2FleetCloudTest {
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
                 false, 0, 1, 1, 1, false,
-                false, false, 0, 0, false, 10);
+                false, false, 0, 0, false,
+                10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 3, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -433,7 +445,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 1, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         // when
         FleetStateStats stats = fleetCloud.update();
@@ -457,7 +469,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -488,7 +500,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -522,7 +534,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -557,7 +569,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 5, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -591,7 +603,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, null, false,
                 false, 0, 0, 10, 1,
                 false, false, false, 0,
-                0, false, 10);
+                0, false, 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 4, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -634,7 +646,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1,
                 false, false, false,
-                0, 0, false, 10);
+                0, 0, false, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -674,7 +686,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, false, 10);
+                0, 0, false, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -717,7 +729,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, false, 10);
+                0, 0, false, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -756,7 +768,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true, 10);
+                0, 0, true, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -795,7 +807,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true, 10);
+                0, 0, true, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -834,7 +846,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true, 10);
+                0, 0, true, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -873,7 +885,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true, 10);
+                0, 0, true, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -912,7 +924,7 @@ public class EC2FleetCloudTest {
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
                 false, 0, 0, 1, 1, false,
                 true, false,
-                0, 0, true, 10);
+                0, 0, true, 10, false);
 
         ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
         doNothing().when(jenkins).addNode(nodeCaptor.capture());
@@ -1160,7 +1172,7 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false, 10, false);
         assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
     }
 
@@ -1171,7 +1183,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false,
+                10, false);
         assertEquals(ec2FleetCloud.getDisplayName(), "CloudName");
     }
 
@@ -1182,7 +1195,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false,
+                10, false);
         Assert.assertNull(ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1193,7 +1207,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false,
+                10, false);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1204,7 +1219,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false,
+                10, false);
         assertEquals("Opa", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1215,7 +1231,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 10);
+                , 0, 0, false,
+                10, false);
         assertEquals("A", ec2FleetCloud.getAwsCredentialsId());
     }
 
@@ -1228,7 +1245,8 @@ public class EC2FleetCloudTest {
                 null, null, null, false,
                 false, null, null, null,
                 null, false, false, false
-                , 0, 0, false, 45);
+                , 0, 0, false,
+                45, false);
         assertEquals(45, ec2FleetCloud.getCloudStatusIntervalSec());
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithHistory.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithHistory.java
@@ -1,0 +1,41 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.model.Label;
+import hudson.slaves.ComputerConnector;
+import hudson.slaves.NodeProvisioner;
+
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+
+public class EC2FleetCloudWithHistory extends EC2FleetCloud {
+
+    public CopyOnWriteArrayList<Long> provisionTimes = new CopyOnWriteArrayList<>();
+
+    public EC2FleetCloudWithHistory(String name, String oldId, String awsCredentialsId, String credentialsId, String region, String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector, boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit, Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight, Integer cloudStatusIntervalSec, boolean immediatelyProvision) {
+        super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot, computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors, addNodeOnlyIfRunning, restrictUsage, disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec, scaleExecutorsByWeight, cloudStatusIntervalSec, immediatelyProvision);
+    }
+
+    @Override
+    public Collection<NodeProvisioner.PlannedNode> provision(
+            final Label label, final int excessWorkload) {
+        final Collection<NodeProvisioner.PlannedNode> r = super.provision(label, excessWorkload);
+        for (NodeProvisioner.PlannedNode ignore : r) provisionTimes.add(System.currentTimeMillis());
+        return r;
+    }
+
+//    @Override
+//    public FleetStateStats update() {
+//        try (Meter.Shot s = updateMeter.start()) {
+//            return super.update();
+//        }
+//    }
+
+//    @Override
+//    public boolean scheduleToTerminate(final String instanceId) {
+//        try (Meter.Shot s = removeMeter.start()) {
+//            return super.scheduleToTerminate(instanceId);
+//        }
+//    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
@@ -9,12 +9,12 @@ import java.util.Collection;
 
 public class EC2FleetCloudWithMeter extends EC2FleetCloud {
 
-    public transient Meter updateMeter = new Meter("update");
-    public transient Meter provisionMeter = new Meter("provision");
-    public transient Meter removeMeter = new Meter("remove");
+    public final Meter updateMeter = new Meter("update");
+    public final Meter provisionMeter = new Meter("provision");
+    public final Meter removeMeter = new Meter("remove");
 
-    public EC2FleetCloudWithMeter(String name, String oldId, String awsCredentialsId, String credentialsId, String region, String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector, boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit, Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight, Integer cloudStatusIntervalSec) {
-        super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot, computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors, addNodeOnlyIfRunning, restrictUsage, disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec, scaleExecutorsByWeight, cloudStatusIntervalSec);
+    public EC2FleetCloudWithMeter(String name, String oldId, String awsCredentialsId, String credentialsId, String region, String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector, boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit, Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight, Integer cloudStatusIntervalSec, boolean immediatelyProvision) {
+        super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot, computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors, addNodeOnlyIfRunning, restrictUsage, disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec, scaleExecutorsByWeight, cloudStatusIntervalSec, immediatelyProvision);
     }
 
     @Override

--- a/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyPerformanceTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyPerformanceTest.java
@@ -1,0 +1,135 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.services.ec2.model.InstanceStateName;
+import hudson.model.FreeStyleBuild;
+import hudson.model.queue.QueueTaskFuture;
+import hudson.slaves.ComputerConnector;
+import hudson.slaves.NodeProvisioner;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * https://support.cloudbees.com/hc/en-us/articles/115000060512-New-Shared-Agents-Clouds-are-not-being-provisioned-for-my-jobs-in-the-queue-when-I-have-agents-that-are-suspended
+ * <p>
+ * Run example:
+ * https://docs.google.com/spreadsheets/d/e/2PACX-1vSuPWeDJD8xAbvHpyJPigAIMYJyL0YvljjAatutNqaFqUQofTx2PxY-sfqZgfsWqRxMGl2elJErbH5n/pubchart?oid=983520837&format=interactive
+ */
+@Ignore
+public class NoDelayProvisionStrategyPerformanceTest extends IntegrationTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        // zero is unlimited timeout
+        System.setProperty("jenkins.test.timeout", "0");
+        // set default MARGIN for Jenkins
+        System.setProperty(NodeProvisioner.class.getName() + ".MARGIN", Integer.toString(10));
+    }
+
+    @Test
+    public void noDelayProvisionStrategy() throws Exception {
+        test(true);
+    }
+
+    @Test
+    public void defaultProvisionStrategy() throws Exception {
+        test(false);
+    }
+
+    private void test(final boolean noDelay) throws IOException, InterruptedException {
+        final int maxWorkers = 100;
+        final int scheduleInterval = 15;
+        final int batchSize = 9;
+
+        mockEc2ApiToDescribeInstancesWhenModifiedWithDelay(InstanceStateName.Running, 500);
+
+        final ComputerConnector computerConnector = new LocalComputerConnector(j);
+        final String label = "momo";
+        final EC2FleetCloudWithHistory cloud = new EC2FleetCloudWithHistory(null, null, "credId", null, "region",
+                null, "fId", label, null, computerConnector, false, false,
+                1, 0, maxWorkers, 1, true, false,
+                false, 0, 0, false,
+                15, noDelay);
+        j.jenkins.clouds.add(cloud);
+
+        System.out.println("waiting cloud start");
+        // updated plugin requires some init time to get first update
+        // so wait this event to be really correct with perf comparison as old version is not require init time
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                Assert.assertNotNull(cloud.getStats());
+            }
+        });
+
+        // warm up jenkins queue, as it takes some time when jenkins run first task and start scale in/out
+        // so let's run one task and wait it finish
+        System.out.println("waiting warm up task execution");
+        final List<QueueTaskFuture> warmUpTasks = getQueueTaskFutures(1);
+        waitTasksFinish(warmUpTasks);
+
+        final List<ImmutableTriple<Long, Integer, Integer>> metrics = new ArrayList<>();
+        final Thread monitor = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                while (!Thread.interrupted()) {
+                    final int queueSize = j.jenkins.getQueue().countBuildableItems()  // tasks to build
+                            + j.jenkins.getQueue().getPendingItems().size() // tasks to start
+                            + j.jenkins.getLabelAtom(label).getBusyExecutors(); // tasks in progress
+                    final int executors = j.jenkins.getLabelAtom(label).getTotalExecutors();
+                    final ImmutableTriple<Long, Integer, Integer> data = new ImmutableTriple<>(
+                            System.currentTimeMillis(), queueSize, executors);
+                    metrics.add(data);
+                    System.out.println(new Date(data.left) + " " + data.middle + " " + data.right);
+
+                    try {
+                        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException("stopped");
+                    }
+                }
+            }
+        });
+        monitor.start();
+
+        System.out.println("start test");
+        int taskCount = 0;
+        final List<QueueTaskFuture> tasks = new ArrayList<>();
+        for (int i = 0; i < 15; i++) {
+            tasks.addAll((List) getQueueTaskFutures(batchSize));
+            taskCount += batchSize;
+            System.out.println("schedule " + taskCount + " tasks, waiting " + scheduleInterval + " sec");
+            Thread.sleep(TimeUnit.SECONDS.toMillis(scheduleInterval));
+        }
+
+        waitTasksFinish(tasks);
+
+        monitor.interrupt();
+        monitor.join();
+
+        for (ImmutableTriple<Long, Integer, Integer> data : metrics) {
+            System.out.println(data.middle + "  " + data.right);
+        }
+    }
+
+    private static void waitTasksFinish(List<QueueTaskFuture> tasks) {
+        for (final QueueTaskFuture<FreeStyleBuild> task : tasks) {
+            try {
+                task.get();
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyTest.java
@@ -1,0 +1,197 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.model.Label;
+import hudson.model.LoadStatistics;
+import hudson.slaves.Cloud;
+import hudson.slaves.NodeProvisioner;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({NodeProvisioner.StrategyState.class})
+public class NoDelayProvisionStrategyTest {
+
+    @Mock
+    private NodeProvisioner.StrategyState state;
+
+    @Mock
+    private LoadStatistics.LoadStatisticsSnapshot snapshot;
+
+    @Mock
+    private Label label;
+
+    private NoDelayProvisionStrategy strategy;
+
+    private List<Cloud> clouds = new ArrayList<>();
+
+    @Before
+    public void before() {
+        strategy = spy(new NoDelayProvisionStrategy());
+        when(strategy.getClouds()).thenReturn(clouds);
+        when(state.getSnapshot()).thenReturn(snapshot);
+    }
+
+    @Test
+    public void givenNoRequiredCapacity_shouldDoNotScale() {
+        final EC2FleetCloud ec2FleetCloud = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud);
+
+        strategy.apply(state);
+
+        verify(ec2FleetCloud, never()).canProvision(any(Label.class));
+    }
+
+    @Test
+    public void givenAvailableSameAsRequiredCapacity_shouldDoNotScale() {
+        final EC2FleetCloud ec2FleetCloud = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud);
+        when(snapshot.getQueueLength()).thenReturn(10);
+        when(snapshot.getAvailableExecutors()).thenReturn(10);
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED,
+                strategy.apply(state));
+
+        verify(ec2FleetCloud, never()).canProvision(any(Label.class));
+    }
+
+    @Test
+    public void givenNoEC2Cloud_shouldDoNotScale() {
+        when(snapshot.getQueueLength()).thenReturn(10);
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+    }
+
+    @Test
+    public void givenNonEC2Cloud_shouldDoNotScale() {
+        when(snapshot.getQueueLength()).thenReturn(10);
+        clouds.add(mock(Cloud.class));
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+    }
+
+    @Test
+    public void givenEC2CloudWithDisabledNoDelay_shouldDoNotScale() {
+        when(snapshot.getQueueLength()).thenReturn(10);
+        when(state.getLabel()).thenReturn(label);
+
+        final EC2FleetCloud ec2FleetCloud = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud);
+        when(ec2FleetCloud.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud.isNoDelayProvision()).thenReturn(false);
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+        verify(ec2FleetCloud, never()).provision(any(Label.class), anyInt());
+    }
+
+    @Test
+    public void givenEC2CloudWhichCannotProvision_shouldDoNotScale() {
+        when(snapshot.getQueueLength()).thenReturn(10);
+        when(state.getLabel()).thenReturn(label);
+
+        final EC2FleetCloud ec2FleetCloud = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud);
+        when(ec2FleetCloud.canProvision(any(Label.class))).thenReturn(false);
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+        verify(ec2FleetCloud, never()).provision(any(Label.class), anyInt());
+    }
+
+    @Test
+    public void givenEC2CloudsWithEnabledNoDelayAndWithout_shouldDoScalingForOne() {
+        when(snapshot.getQueueLength()).thenReturn(10);
+        when(state.getLabel()).thenReturn(label);
+
+        final EC2FleetCloud ec2FleetCloud1 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud1);
+        final EC2FleetCloud ec2FleetCloud2 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud2);
+        when(ec2FleetCloud1.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud2.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
+        when(ec2FleetCloud2.isNoDelayProvision()).thenReturn(false);
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+        verify(ec2FleetCloud1, times(1)).provision(label, 10);
+        verify(ec2FleetCloud2, never()).provision(any(Label.class), anyInt());
+    }
+
+    @Test
+    public void givenEC2CloudsWhenOneCanCoverCapacity_shouldDoScalingForFirstOnly() {
+        when(snapshot.getQueueLength()).thenReturn(2);
+        when(state.getLabel()).thenReturn(label);
+
+        final EC2FleetCloud ec2FleetCloud1 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud1);
+        final EC2FleetCloud ec2FleetCloud2 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud2);
+        when(ec2FleetCloud1.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud2.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
+        when(ec2FleetCloud2.isNoDelayProvision()).thenReturn(true);
+        when(ec2FleetCloud1.provision(any(Label.class), anyInt())).thenReturn(Arrays.asList(
+                mock(NodeProvisioner.PlannedNode.class),
+                mock(NodeProvisioner.PlannedNode.class)
+        ));
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED,
+                strategy.apply(state));
+        verify(ec2FleetCloud1, times(1)).provision(label, 2);
+        verify(ec2FleetCloud2, never()).provision(any(Label.class), anyInt());
+    }
+
+    @Test
+    public void givenEC2Clouds_shouldDoScalingAndReduceForNextOne() {
+        when(snapshot.getQueueLength()).thenReturn(5);
+        when(state.getLabel()).thenReturn(label);
+
+        final EC2FleetCloud ec2FleetCloud1 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud1);
+        final EC2FleetCloud ec2FleetCloud2 = mock(EC2FleetCloud.class);
+        clouds.add(ec2FleetCloud2);
+        when(ec2FleetCloud1.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud2.canProvision(any(Label.class))).thenReturn(true);
+        when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
+        when(ec2FleetCloud2.isNoDelayProvision()).thenReturn(true);
+        when(ec2FleetCloud1.provision(any(Label.class), anyInt())).thenReturn(Arrays.asList(
+                mock(NodeProvisioner.PlannedNode.class),
+                mock(NodeProvisioner.PlannedNode.class)
+        ));
+
+        Assert.assertEquals(
+                NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES,
+                strategy.apply(state));
+        verify(ec2FleetCloud1, times(1)).provision(label, 5);
+        verify(ec2FleetCloud2, times(1)).provision(label, 3);
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -64,7 +64,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 0, 1, false, false,
-                false, 0, 0, false, 2);
+                false, 0, 0, false,
+                2, false);
         j.jenkins.clouds.add(cloud);
 
         EC2Api ec2Api = spy(EC2Api.class);
@@ -109,7 +110,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false, 2);
+                false, 0, 0, false,
+                2, false);
         j.jenkins.clouds.add(cloud);
 
         List<QueueTaskFuture> rs = getQueueTaskFutures(1);
@@ -139,7 +141,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 300, 15, false, 2));
+                false, 300, 15, false,
+                2, false));
 
         // provide init state
         cloud.setStats(new FleetStateStats("", 0, "active",
@@ -170,7 +173,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         final EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false, 10));
+                false, 0, 0, false,
+                10, false));
         j.jenkins.clouds.add(cloud);
 
         mockEc2ApiToDescribeInstancesWhenModified(InstanceStateName.Running);
@@ -195,7 +199,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, false, false,
-                false, 0, 0, false, 10));
+                false, 0, 0, false,
+                10, false));
 
         cloud.setStats(new FleetStateStats("", 0, "active",
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
@@ -251,7 +256,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false,
-                false, 0, 0, false, 2);
+                false, 0, 0, false,
+                2, false);
         j.jenkins.clouds.add(cloud);
 
         mockEc2ApiToDescribeInstancesWhenModified(InstanceStateName.Pending);
@@ -282,23 +288,25 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 1, 0, 5, 1, true, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         // wait while all nodes will be ok
-        tryUntil(new Runnable() {
-            @Override
-            public void run() {
-                for (Node node : j.jenkins.getNodes()) {
-                    final Computer computer = node.toComputer();
-                    Assert.assertNotNull(computer);
-                    Assert.assertTrue(computer.isOnline());
-                }
-            }
-        });
+//        tryUntil(new Runnable() {
+//            @Override
+//            public void run() {
+//                for (Node node : j.jenkins.getNodes()) {
+//                    final Computer computer = node.toComputer();
+//                    Assert.assertNotNull(computer);
+//                    Assert.assertTrue(computer.isOnline());
+//                }
+//            }
+//        });
 
         final List<QueueTaskFuture<FreeStyleBuild>> tasks = new ArrayList<>();
         tasks.addAll((List) getQueueTaskFutures(5));
+        System.out.println("tasks submitted");
 
         // wait full execution
         for (final QueueTaskFuture<FreeStyleBuild> task : tasks) {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -285,7 +285,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         mockEc2ApiToDescribeInstancesWhenModified(InstanceStateName.Running, 5);
 
         final ComputerConnector computerConnector = new LocalComputerConnector(j);
-        final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
+        final EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 1, 0, 5, 1, true, false,
                 false, 0, 0, false,

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
@@ -42,7 +42,8 @@ public class ProvisionPerformanceTest extends IntegrationTest {
         final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 1, 0, workers, 1, true, false,
-                false, 0, 0, false, 2);
+                false, 0, 0, false,
+                2, false);
         j.jenkins.clouds.add(cloud);
 
         // updated plugin requires some init time to get first update

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealEc2ApiIntegrationTest.java
@@ -51,7 +51,8 @@ public class RealEc2ApiIntegrationTest {
                 EC2FleetCloud cloud = new EC2FleetCloud("", null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false,
-                        false, 0, 0, false, 10);
+                        false, 0, 0, false,
+                        10, false);
                 j.jenkins.clouds.add(cloud);
 
                 // 10 sec refresh time so wait
@@ -84,7 +85,7 @@ public class RealEc2ApiIntegrationTest {
                 EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, null, null, fleetId,
                         null, null, null, false, false,
                         0, 0, 0, 0, false, false,
-                        false, 0, 0, false, 10);
+                        false, 0, 0, false, 10, false);
                 j.jenkins.clouds.add(cloud);
 
                 final long start = System.currentTimeMillis();

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -50,7 +50,8 @@ public class UiIntegrationTest {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -63,7 +64,8 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         j.jenkins.addNode(new EC2FleetNode("node-name", "", "", 1,
@@ -80,7 +82,8 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         j.jenkins.addNode(new EC2FleetNode("mock", "", "", 1,
@@ -105,7 +108,8 @@ public class UiIntegrationTest {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -118,13 +122,15 @@ public class UiIntegrationTest {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -140,13 +146,15 @@ public class UiIntegrationTest {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -162,13 +170,15 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud2);
 
         HtmlPage page = j.createWebClient().goTo("configure");
@@ -187,13 +197,15 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("FleetCloud"));
@@ -204,13 +216,15 @@ public class UiIntegrationTest {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
                 0, 0, 0, 0, false, false,
-                false, 0, 0, false, 10);
+                false, 0, 0, false,
+                10, false);
         j.jenkins.clouds.add(cloud2);
 
         assertSame(cloud1, j.jenkins.getCloud("a"));


### PR DESCRIPTION
## Motivation
Jenkins designed to keep capacity as small as possible. It prefers to wait some time when queue has enough pending jobs or pending time reachs some limit. This creates additonal delays between job scheduling and actual execution. 

Historically new capacity is not easy to add or expensive to use for short time. This is not the case for EC2 Linux based instances with per minute billing.

This change added feature to turn off Jenkins default conservative capacity approach and force Jenkins to request new capacity as soon as new job appears in queue and there are no free capacity to execute.

## Done
- New configuration option ```No Delay Provision Strategy``` when enabled forces Jenkins to request new capacity immediately.

## Implementation
- New provision startegy with high order created ```NoDelayProvisionStrategy```
- It will be applied If any of ```EC2FleetCloud``` has enabled ```NoDelayProvision``` property, otherwise it will fallback to ```NodeProvisioner.StandardStrategyImpl``` which is default one.

## Result

Chart below shows how enabled ```NoDelayProvisionStrategy``` improve Jenkins reaction speed, in particular scenario no delay safes ```2 min``` for build time compare to default
- Scenario ```NoDelayProvisionStrategyPerformanceTest``` during some period of time, each ```X``` second schedule ```Y``` jobs.
- *Note* interesting part that in particlar case old approach request even more capacity then no delay due to slow reaction on queue size.

<img width="1014" alt="Screen Shot 2019-10-08 at 9 34 36 AM" src="https://user-images.githubusercontent.com/473022/66414754-e067ef80-e9ae-11e9-8ad1-3844736e70c9.png">

