### PR TITLE
Tag ec2 instances

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -5,11 +5,13 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
@@ -143,6 +145,16 @@ public class EC2Api {
                 }
             }
         }
+    }
+
+    public void tagInstances(final AmazonEC2 ec2, final Set<String> instanceIds, final String tag) {
+        if (instanceIds.isEmpty()) return;
+
+        final CreateTagsRequest request = new CreateTagsRequest()
+                .withResources(instanceIds)
+                // if you don't need value EC2 API requires empty string
+                .withTags(Collections.singletonList(new Tag().withKey(tag).withValue("")));
+        ec2.createTags(request);
     }
 
     public AmazonEC2 connect(final String awsCredentialsId, final String regionName, final String endpoint) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -147,13 +147,13 @@ public class EC2Api {
         }
     }
 
-    public void tagInstances(final AmazonEC2 ec2, final Set<String> instanceIds, final String tag) {
+    public void tagInstances(final AmazonEC2 ec2, final Set<String> instanceIds, final String key, final String value) {
         if (instanceIds.isEmpty()) return;
 
         final CreateTagsRequest request = new CreateTagsRequest()
                 .withResources(instanceIds)
                 // if you don't need value EC2 API requires empty string
-                .withTags(Collections.singletonList(new Tag().withKey(tag).withValue("")));
+                .withTags(Collections.singletonList(new Tag().withKey(key).withValue(value == null ? "" : value)));
         ec2.createTags(request);
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -513,7 +513,7 @@ public class EC2FleetCloud extends Cloud {
                 Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(),
                         EC2_INSTANCE_CLOUD_NAME_TAG, name);
             } catch (final Exception e) {
-                warning("failed to tag new instances %s, skip", newFleetInstances.keySet());
+                warning(e, "failed to tag new instances %s, skip", newFleetInstances.keySet());
             }
 
             // addNewSlave will call addNode which call queue lock

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -509,7 +509,7 @@ public class EC2FleetCloud extends Cloud {
             // we tag new instances to help users to identify instances launched from plugin managed fleets
             // if failed we are fine to skip this call
             try {
-                Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(), EC2_INSTANCE_TAG);
+                Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(), EC2_INSTANCE_TAG, name);
             } catch (final Exception e) {
                 warning("failed to tag new instances %s, skip", newFleetInstances.keySet());
             }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -59,7 +59,8 @@ import java.util.logging.SimpleFormatter;
 @SuppressWarnings({"unused", "WeakerAccess"})
 public class EC2FleetCloud extends Cloud {
 
-    public static final String EC2_INSTANCE_TAG = "ec2-fleet-plugin";
+    public static final String EC2_INSTANCE_TAG_NAMESPACE = "ec2-fleet-plugin";
+    public static final String EC2_INSTANCE_CLOUD_NAME_TAG = EC2_INSTANCE_TAG_NAMESPACE + ":cloud-name";
 
     public static final String FLEET_CLOUD_ID = "FleetCloud";
 
@@ -509,7 +510,8 @@ public class EC2FleetCloud extends Cloud {
             // we tag new instances to help users to identify instances launched from plugin managed fleets
             // if failed we are fine to skip this call
             try {
-                Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(), EC2_INSTANCE_TAG, name);
+                Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(),
+                        EC2_INSTANCE_CLOUD_NAME_TAG, name);
             } catch (final Exception e) {
                 warning("failed to tag new instances %s, skip", newFleetInstances.keySet());
             }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -2,13 +2,16 @@ package com.amazon.jenkins.ec2fleet;
 
 import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.AmazonEC2Exception;
+import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.Tag;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -281,6 +284,27 @@ public class EC2ApiTest {
         } catch (UnsupportedOperationException e) {
             Assert.assertSame(exception, e);
         }
+    }
+
+    @Test
+    public void tagInstances_shouldDoNothingIfNoInstancesPassed() {
+        // when
+        new EC2Api().tagInstances(amazonEC2, Collections.<String>emptySet(), "opa");
+
+        // then
+        verifyZeroInteractions(amazonEC2);
+    }
+
+    @Test
+    public void tagInstances_shouldTag() {
+        // when
+        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa");
+
+        // then
+        verify(amazonEC2).createTags(new CreateTagsRequest()
+                .withResources(ImmutableSet.of("i-1", "i-2"))
+                .withTags(new Tag().withKey("opa").withValue("")));
+        verifyNoMoreInteractions(amazonEC2);
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -289,7 +289,7 @@ public class EC2ApiTest {
     @Test
     public void tagInstances_shouldDoNothingIfNoInstancesPassed() {
         // when
-        new EC2Api().tagInstances(amazonEC2, Collections.<String>emptySet(), "opa");
+        new EC2Api().tagInstances(amazonEC2, Collections.<String>emptySet(), "opa", "v");
 
         // then
         verifyZeroInteractions(amazonEC2);
@@ -298,7 +298,19 @@ public class EC2ApiTest {
     @Test
     public void tagInstances_shouldTag() {
         // when
-        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa");
+        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa", "v");
+
+        // then
+        verify(amazonEC2).createTags(new CreateTagsRequest()
+                .withResources(ImmutableSet.of("i-1", "i-2"))
+                .withTags(new Tag().withKey("opa").withValue("v")));
+        verifyNoMoreInteractions(amazonEC2);
+    }
+
+    @Test
+    public void tagInstances_givenNullValueShouldTagWithEmptyValue() {
+        // when
+        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa", null);
 
         // then
         verify(amazonEC2).createTags(new CreateTagsRequest()

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -695,7 +695,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0", "i-1"), "ec2-fleet-plugin", "FleetCloud");
+        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0", "i-1"), "ec2-fleet-plugin:cloud-name", "FleetCloud");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
@@ -729,7 +729,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin", "my-fleet");
+        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin:cloud-name", "my-fleet");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
@@ -767,7 +767,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin", "FleetCloud");
+        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin:cloud-name", "FleetCloud");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.verify;
@@ -660,6 +661,79 @@ public class EC2FleetCloudTest {
         assertEquals("fleetId", stats.getFleetId());
 
         // and
+        Node actualFleetNode = nodeCaptor.getValue();
+        assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
+    }
+
+    @Test
+    public void update_shouldTagNewNodesBeforeAdding() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        final Instance instance1 = new Instance().withPublicIpAddress("p-ip").withInstanceId("i-0");
+        final Instance instance2 = new Instance().withPublicIpAddress("p-ip").withInstanceId("i-1");
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                ImmutableMap.of("i-0", instance1, "i-1", instance2));
+
+        PowerMockito.when(FleetStateStats.readClusterState(any(AmazonEC2.class), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("fleetId", 0, "active",
+                        ImmutableSet.of("i-0", "i-1"), Collections.<String, Double>emptyMap()));
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 2, 1,
+                false, false, false,
+                0, 0, false, 10, false);
+
+        ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
+        doNothing().when(jenkins).addNode(nodeCaptor.capture());
+
+        // when
+        fleetCloud.update();
+
+        // then
+        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0", "i-1"), "ec2-fleet-plugin");
+        Node actualFleetNode = nodeCaptor.getValue();
+        assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
+    }
+
+    @Test
+    public void update_givenFailedTaggingShouldIgnoreExceptionAndAddNode() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+        doThrow(new UnsupportedOperationException("testexception"))
+                .when(ec2Api).tagInstances(any(AmazonEC2.class), any(Set.class), anyString());
+
+        final Instance instance = new Instance()
+                .withPublicIpAddress("p-ip")
+                .withInstanceId("i-0");
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                ImmutableMap.of("i-0", instance));
+
+        PowerMockito.when(FleetStateStats.readClusterState(any(AmazonEC2.class), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("fleetId", 0, "active",
+                        ImmutableSet.of("i-0"), Collections.<String, Double>emptyMap()));
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 1, 1,
+                false, false, false,
+                0, 0, false, 10, false);
+
+        ArgumentCaptor<Node> nodeCaptor = ArgumentCaptor.forClass(Node.class);
+        doNothing().when(jenkins).addNode(nodeCaptor.capture());
+
+        // when
+        fleetCloud.update();
+
+        // then
+        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }


### PR DESCRIPTION
Plugin automatically adds cloud name as EC2 instance tag. Format:
```
ec2-fleet-plugin:cloud-name=<cloudName>
```
As result you AWS Console you can easelly find all EC2 instances launched by Plugin if search by ```ec2-fleet-plugin``` or subset of EC2 instances launched for particular cloud ```ec2-fleet-plugin:cloud-name=MyCloud```

**Note** this is non critical feature, if it will fail plugin will continue work without assigned tags. Make sure user which you specify in plugin configuration has ```ec2:CreateTags``` permissions
