### PR TITLE
Terminate instances after spot fleet modify

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2SpotFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2SpotFleet.java
@@ -73,7 +73,7 @@ public class EC2SpotFleet implements EC2Fleet {
         final ModifySpotFleetRequestRequest request = new ModifySpotFleetRequestRequest();
         request.setSpotFleetRequestId(id);
         request.setTargetCapacity(targetCapacity);
-        request.setExcessCapacityTerminationPolicy("NoTermination");
+        request.setExcessCapacityTerminationPolicy("Default");
 
         final AmazonEC2 ec2 = Registry.getEc2Api().connect(awsCredentialsId, regionName, endpoint);
         ec2.modifySpotFleetRequest(request);


### PR DESCRIPTION
When debugging the autoscaling issues in #149 I discovered that the excess termination policy is set to NoTerminate from this plugin. Causing spot instances to hang around until they are eventually reclaimed by AWS. This seems to cause issues when scaling up and down as the requested capacity and actual capacity never aligns.