### PR TITLE
Handle eEC2 Spot Fleet modifying state

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -313,6 +314,11 @@ public class EC2FleetCloud extends Cloud {
     }
 
     @VisibleForTesting
+    synchronized Set<NodeProvisioner.PlannedNode> getPlannedNodesCache() {
+        return plannedNodesCache;
+    }
+
+    @VisibleForTesting
     synchronized Set<String> getInstanceIdsToTerminate() {
         return instanceIdsToTerminate;
     }
@@ -398,13 +404,57 @@ public class EC2FleetCloud extends Cloud {
             currentInstanceIdsToTerminate = new HashSet<>(instanceIdsToTerminate);
         }
 
+        // plugin loads fleet state before possible modification and adjust current state
+        // with fixed target capacity, because not all implementations of EC2Fleet updates
+        // fleet state immediately and if you do update then load state you can get inconsistent
+        // state, see EC2SpotFleet doc
+        FleetStateStats currentState = EC2Fleets.get(fleet).getState(
+                getAwsCredentialsId(), region, endpoint, getFleet());
+        if (currentState.getState().isModifying()) {
+            info("Fleet under modification, try update later, %s", currentState.getState().getDetailed());
+            synchronized (this) {
+                stats = currentState;
+            }
+            return stats;
+        }
+
+        // fleet could be updated outside of plugin, we should be ready that
+        // real target capacity is zero or less then plugin thinks and make sure
+        // new target capacity will not be negative
+        final int targetCapacity = Math.max(0,
+                currentState.getNumDesired() - currentInstanceIdsToTerminate.size() + currentToAdd);
+        currentState = new FleetStateStats(currentState, targetCapacity);
+
+        updateByState(currentToAdd, currentInstanceIdsToTerminate, targetCapacity, currentState);
+
+        // lock and update state of plugin, so terminate or provision could work with new state of world
+        synchronized (this) {
+            instanceIdsToTerminate.removeAll(currentInstanceIdsToTerminate);
+            // toAdd only grow outside of this method, so we can subtract
+            toAdd = toAdd - currentToAdd;
+            stats = currentState;
+            // limit planned pool according to real target capacity
+            while (plannedNodesCache.size() > targetCapacity) {
+                final Iterator<NodeProvisioner.PlannedNode> iterator = plannedNodesCache.iterator();
+                final NodeProvisioner.PlannedNode plannedNodeToCancel = iterator.next();
+                iterator.remove();
+                // cancel to let jenkins no that node is not valid any more
+                plannedNodeToCancel.future.cancel(true);
+            }
+        }
+
+        return stats;
+    }
+
+    private void updateByState(
+            final int currentToAdd, final Set<String> currentInstanceIdsToTerminate,
+            final int targetCapacity, final FleetStateStats newStatus) {
         final Jenkins jenkins = Jenkins.getInstance();
 
         final AmazonEC2 ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
 
         if (currentToAdd > 0 || currentInstanceIdsToTerminate.size() > 0) {
             // todo fix negative value
-            final int targetCapacity = stats.getNumDesired() - currentInstanceIdsToTerminate.size() + toAdd;
             // we do update any time even real capacity was not update like remove one add one to
             // update fleet settings with NoTermination so we can terminate instances on our own
             EC2Fleets.get(fleet).modify(
@@ -437,13 +487,11 @@ public class EC2FleetCloud extends Cloud {
             info("Instances %s were terminated with result", currentInstanceIdsToTerminate);
         }
 
-        final FleetStateStats currentStats = EC2Fleets.get(fleet).getState(
-                getAwsCredentialsId(), region, endpoint, getFleet());
-        info("fleet instances %s", currentStats.getInstances());
+        info("fleet instances %s", newStatus.getInstances());
 
         // Set up the lists of Jenkins nodes and fleet instances
         // currentFleetInstances contains instances currently in the fleet
-        final Set<String> fleetInstances = new HashSet<>(currentStats.getInstances());
+        final Set<String> fleetInstances = new HashSet<>(newStatus.getInstances());
 
         final Map<String, Instance> described = Registry.getEc2Api().describeInstances(ec2, fleetInstances);
         info("described instances %s", described.keySet());
@@ -516,7 +564,7 @@ public class EC2FleetCloud extends Cloud {
                 public void run() {
                     try {
                         for (final Instance instance : newFleetInstances.values()) {
-                            addNewSlave(ec2, instance, currentStats);
+                            addNewSlave(ec2, instance, newStatus);
                         }
                     } catch (final Exception ex) {
                         warning(ex, "Unable to set label on node");
@@ -524,16 +572,6 @@ public class EC2FleetCloud extends Cloud {
                 }
             });
         }
-
-        // lock and update state of plugin, so terminate or provision could work with new state of world
-        synchronized (this) {
-            instanceIdsToTerminate.removeAll(currentInstanceIdsToTerminate);
-            // toAdd only grow outside of this method, so we can subtract
-            toAdd = toAdd - currentToAdd;
-            stats = currentStats;
-        }
-
-        return stats;
     }
 
     /**

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -403,6 +403,7 @@ public class EC2FleetCloud extends Cloud {
         final AmazonEC2 ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
 
         if (currentToAdd > 0 || currentInstanceIdsToTerminate.size() > 0) {
+            // todo fix negative value
             final int targetCapacity = stats.getNumDesired() - currentInstanceIdsToTerminate.size() + toAdd;
             // we do update any time even real capacity was not update like remove one add one to
             // update fleet settings with NoTermination so we can terminate instances on our own

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidget.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidget.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 /**
  * This class should be thread safe, consumed by Jenkins and updated
- * by {@link CloudNanny}
+ * by {@link EC2FleetStatusWidgetUpdater}
  */
 @Extension
 @ThreadSafe

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdater.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdater.java
@@ -1,0 +1,73 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.google.common.annotations.VisibleForTesting;
+import hudson.Extension;
+import hudson.model.PeriodicWork;
+import hudson.slaves.Cloud;
+import hudson.widgets.Widget;
+import jenkins.model.Jenkins;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @see EC2FleetCloud
+ * @see EC2FleetStatusWidget
+ */
+@Extension
+@SuppressWarnings("unused")
+public class EC2FleetStatusWidgetUpdater extends PeriodicWork {
+
+    @Override
+    public long getRecurrencePeriod() {
+        return 10000L;
+    }
+
+    /**
+     * <h2>Exceptions</h2>
+     * This method will be executed by {@link PeriodicWork} inside {@link java.util.concurrent.ScheduledExecutorService}
+     * by default it stops execution if task throws exception, however {@link PeriodicWork} fix that
+     * by catch any exception and just log it, so we safe to throw exception here.
+     */
+    @Override
+    protected void doRun() {
+        final List<EC2FleetStatusInfo> info = new ArrayList<>();
+        for (final Cloud cloud : getClouds()) {
+            if (!(cloud instanceof EC2FleetCloud)) continue;
+            final EC2FleetCloud fleetCloud = (EC2FleetCloud) cloud;
+            final FleetStateStats stats = fleetCloud.getStats();
+            // could be when plugin just started and not yet updated, ok to skip
+            if (stats == null) continue;
+
+            info.add(new EC2FleetStatusInfo(
+                    fleetCloud.getFleet(), stats.getState().getDetailed(), fleetCloud.getLabelString(),
+                    stats.getNumActive(), stats.getNumDesired()));
+        }
+
+        for (final Widget w : getWidgets()) {
+            if (w instanceof EC2FleetStatusWidget) ((EC2FleetStatusWidget) w).setStatusList(info);
+        }
+    }
+
+    /**
+     * Will be mocked by tests to avoid deal with jenkins
+     *
+     * @return widgets
+     */
+    @VisibleForTesting
+    private static List<Widget> getWidgets() {
+        return Jenkins.getActiveInstance().getWidgets();
+    }
+
+    /**
+     * We return {@link List} instead of original {@link Jenkins.CloudList}
+     * to simplify testing as jenkins list requires actual {@link Jenkins} instance.
+     *
+     * @return basic java list
+     */
+    @VisibleForTesting
+    private static List<Cloud> getClouds() {
+        return Jenkins.getActiveInstance().clouds;
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
@@ -1,10 +1,8 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 import hudson.slaves.Cloud;
-import hudson.widgets.Widget;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +19,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,14 +35,6 @@ public class CloudNannyTest {
 
     @Mock
     private EC2FleetCloud cloud2;
-
-    @Mock
-    private EC2FleetStatusWidget widget1;
-
-    @Mock
-    private EC2FleetStatusWidget widget2;
-
-    private List<Widget> widgets = new ArrayList<>();
 
     private List<Cloud> clouds = new ArrayList<>();
 
@@ -69,7 +58,6 @@ public class CloudNannyTest {
     public void before() throws Exception {
         PowerMockito.mockStatic(CloudNanny.class);
         PowerMockito.when(CloudNanny.class, "getClouds").thenReturn(clouds);
-        PowerMockito.when(CloudNanny.class, "getWidgets").thenReturn(widgets);
 
         when(cloud1.getLabelString()).thenReturn("a");
         when(cloud2.getLabelString()).thenReturn("");
@@ -112,40 +100,11 @@ public class CloudNannyTest {
     }
 
     @Test
-    public void shouldUpdateCloudCollectResultAndUpdateWidgets() {
-        clouds.add(cloud1);
-
-        widgets.add(widget1);
-
-        getMockCloudNannyInstance().doRun();
-
-        verify(widget1).setStatusList(ImmutableList.of(new EC2FleetStatusInfo(
-                cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired())));
-    }
-
-    @Test
-    public void shouldUpdateCloudCollectResultAndUpdateAllEC2FleetWidgets() {
-        clouds.add(cloud1);
-
-        widgets.add(widget1);
-        widgets.add(widget2);
-
-        getMockCloudNannyInstance().doRun();
-
-        verify(widget1).setStatusList(ImmutableList.of(new EC2FleetStatusInfo(
-                cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired())));
-        verify(widget2).setStatusList(ImmutableList.of(new EC2FleetStatusInfo(
-                cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired())));
-    }
-
-    @Test
     public void shouldIgnoreNonEC2FleetClouds() {
         clouds.add(cloud1);
 
         Cloud nonEc2FleetCloud = mock(Cloud.class);
         clouds.add(nonEc2FleetCloud);
-
-        widgets.add(widget2);
 
         getMockCloudNannyInstance().doRun();
 
@@ -154,18 +113,14 @@ public class CloudNannyTest {
     }
 
     @Test
-    public void shouldUpdateCloudCollectAllResultAndUpdateWidgets() {
+    public void shouldUpdateCloudCollectAll() {
         clouds.add(cloud1);
         clouds.add(cloud2);
 
-        widgets.add(widget1);
-
         getMockCloudNannyInstance().doRun();
 
-        verify(widget1).setStatusList(ImmutableList.of(
-                new EC2FleetStatusInfo(cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired()),
-                new EC2FleetStatusInfo(cloud2.getFleet(), stats2.getState().getDetailed(), cloud2.getLabelString(), stats2.getNumActive(), stats2.getNumDesired())
-        ));
+        verify(cloud1).update();
+        verify(cloud2).update();
     }
 
     @Test
@@ -175,29 +130,10 @@ public class CloudNannyTest {
 
         when(cloud1.update()).thenThrow(new IllegalArgumentException("test"));
 
-        widgets.add(widget1);
-
         getMockCloudNannyInstance().doRun();
 
-        verify(widget1).setStatusList(ImmutableList.of(
-                new EC2FleetStatusInfo(cloud2.getFleet(), stats2.getState().getDetailed(), cloud2.getLabelString(), stats2.getNumActive(), stats2.getNumDesired())
-        ));
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void shouldIgnoreNonEc2FleetWidgets() {
-        clouds.add(cloud1);
-
-        Widget nonEc2FleetWidget = mock(Widget.class);
-        widgets.add(nonEc2FleetWidget);
-
-        widgets.add(widget1);
-
-        getMockCloudNannyInstance().doRun();
-
-        verify(widget1).setStatusList(any(List.class));
-        verifyZeroInteractions(nonEc2FleetWidget);
+        verify(cloud1).update();
+        verify(cloud2).update();
     }
 
     @Test
@@ -220,7 +156,6 @@ public class CloudNannyTest {
 
     @Test
     public void skipCloudIntervalExecution() {
-        widgets.add(widget1);
         clouds.add(cloud1);
         clouds.add(cloud2);
         CloudNanny cloudNanny = getMockCloudNannyInstance();
@@ -235,9 +170,6 @@ public class CloudNannyTest {
 
         assertEquals(1, recurrenceCounter1.get());
         assertEquals(2, recurrenceCounter2.get());
-
-        // commented because of bug https://github.com/jenkinsci/ec2-fleet-plugin/issues/147
-        // verifyZeroInteractions(widget1, widget2);
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
@@ -39,10 +39,10 @@ public class CloudNannyTest {
     private List<Cloud> clouds = new ArrayList<>();
 
     private FleetStateStats stats1 = new FleetStateStats(
-            "f1", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f1", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
 
     private FleetStateStats stats2 = new FleetStateStats(
-            "f2", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f2", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
 
     private int recurrencePeriod = 45;
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.nullable;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -498,9 +499,10 @@ public class EC2FleetCloudTest {
         // given
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
+        final FleetStateStats currentState = new FleetStateStats("fleetId", 5, FleetStateStats.State.active(),
+                Collections.<String>emptySet(), Collections.<String, Double>emptyMap());
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                .thenReturn(currentState);
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
@@ -508,8 +510,7 @@ public class EC2FleetCloudTest {
                 false, false, 0,
                 0, false, 10, false);
 
-        fleetCloud.setStats(new FleetStateStats("", 5, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+        fleetCloud.setStats(currentState);
 
         fleetCloud.provision(null, 2);
         fleetCloud.scheduleToTerminate("i-1");
@@ -560,7 +561,7 @@ public class EC2FleetCloudTest {
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
+                .thenReturn(new FleetStateStats("fleetId", 5, FleetStateStats.State.active(),
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
@@ -590,7 +591,7 @@ public class EC2FleetCloudTest {
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
+                .thenReturn(new FleetStateStats("fleetId", 4, FleetStateStats.State.active(),
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
@@ -839,6 +840,166 @@ public class EC2FleetCloudTest {
     }
 
     @Test
+    public void update_givenManuallyUpdatedFleetShouldCorrectLocalTargetCapacityToKeepZeroOrPositive() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                Collections.emptyMap());
+
+        final FleetStateStats initState = new FleetStateStats("fleetId", 0,
+                FleetStateStats.State.active(),
+                ImmutableSet.of("i-0", "i-1"), Collections.<String, Double>emptyMap());
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(initState);
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 10, 1, false,
+                true, false,
+                0, 0, false, 10, false);
+        fleetCloud.setStats(initState);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        fleetCloud.scheduleToTerminate("i-0");
+        fleetCloud.scheduleToTerminate("i-1");
+
+        // when
+        fleetCloud.update();
+
+        // then
+        // should reset list to empty
+        verify(ec2Fleet).modify(anyString(), anyString(), anyString(), anyString(), anyInt(), anyInt(), anyInt());
+        Assert.assertEquals(0, fleetCloud.getPlannedNodesCache().size());
+    }
+
+    @Test
+    public void update_shouldTrimPlannedNodesIfExceedTargetCapacity() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                Collections.emptyMap());
+
+        final FleetStateStats initState = new FleetStateStats("fleetId", 0,
+                FleetStateStats.State.active(),
+                Collections.<String>emptySet(), Collections.<String, Double>emptyMap());
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(initState);
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 10, 1, false,
+                true, false,
+                0, 0, false, 10, false);
+        fleetCloud.setStats(initState);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        // when
+        fleetCloud.provision(null, 10);
+        // try to modify and reset to add
+        fleetCloud.update();
+        // reset to old empty state
+        fleetCloud.setStats(initState);
+        fleetCloud.update();
+
+        // then
+        // should reset list to empty
+        Assert.assertEquals(0, fleetCloud.getPlannedNodesCache().size());
+    }
+
+    // todo check that trimmed were cancelled
+
+    @Test
+    public void update_shouldUpdateStateWithFleetTargetCapacityPlusToAdd() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        final String instanceType = "t";
+        final Instance instance = new Instance()
+                .withPublicIpAddress("p-ip")
+                .withInstanceType(instanceType)
+                .withInstanceId("i-0");
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                ImmutableMap.of("i-0", instance));
+
+        final FleetStateStats initState = new FleetStateStats("fleetId", 5,
+                FleetStateStats.State.active(),
+                Collections.<String>emptySet(), Collections.<String, Double>emptyMap());
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(initState);
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 10, 1, false,
+                true, false,
+                0, 0, false, 10, false);
+        fleetCloud.setStats(initState);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        fleetCloud.provision(null, 2);
+
+        // when
+        fleetCloud.update();
+
+        // then
+        Assert.assertEquals(7, fleetCloud.getStats().getNumDesired());
+    }
+
+    /**
+     * See {@link EC2FleetCloudTest#update_shouldUpdateStateWithFleetTargetCapacityPlusToAdd()}
+     */
+    @Test
+    public void update_shouldUpdateStateWithFleetTargetCapacityMinusToTerminate() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        final String instanceType = "t";
+        final Instance instance = new Instance()
+                .withPublicIpAddress("p-ip")
+                .withInstanceType(instanceType)
+                .withInstanceId("i-0");
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                ImmutableMap.of("i-0", instance));
+
+        final FleetStateStats initState = new FleetStateStats("fleetId", 5,
+                FleetStateStats.State.active(),
+                ImmutableSet.<String>of("i-0"), Collections.<String, Double>emptyMap());
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(initState);
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 10, 1, false,
+                true, false,
+                0, 0, false, 10, false);
+        fleetCloud.setStats(initState);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        fleetCloud.scheduleToTerminate("i-0");
+
+        // when
+        fleetCloud.update();
+
+        // then
+        Assert.assertEquals(4, fleetCloud.getStats().getNumDesired());
+    }
+
+    @Test
     public void update_shouldAddNodeWithScaledNumExecutors_whenWeightPresentAndEnabled() throws IOException {
         // given
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
@@ -995,7 +1156,7 @@ public class EC2FleetCloudTest {
     }
 
     @Test
-    public void update_shouldAddNodeWithScaledToOneNumExecutors_whenWeightPresentButLessOneAndEnabled() throws IOException {
+    public void update_shouldAddNodeWithScaledToOneNumExecutors_whenWeightPresentButLessOneAndEnabled() {
         // given
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
@@ -1074,6 +1235,47 @@ public class EC2FleetCloudTest {
         // then
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(1, actualFleetNode.getNumExecutors());
+    }
+
+    @Test
+    public void update_givenFleetInModifyingShouldStopAndNotUpdateAddOrModify() throws IOException {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        final String instanceType = "t";
+        final String instanceId = "i-0";
+        final Instance instance = new Instance()
+                .withPublicIpAddress("p-ip")
+                .withInstanceType(instanceType)
+                .withInstanceId(instanceId);
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                ImmutableMap.of(instanceId, instance));
+
+        final FleetStateStats stats = new FleetStateStats("fleetId", 0,
+                FleetStateStats.State.modifying(""),
+                ImmutableSet.of(instanceId),
+                ImmutableMap.of(instanceType, .1));
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(stats);
+
+        mockNodeCreatingPart();
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 1, 1, false,
+                true, false,
+                0, 0, true, 10, false);
+        fleetCloud.setStats(stats);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        // when
+        FleetStateStats newStats = fleetCloud.update();
+
+        // then
+        Assert.assertSame(stats, newStats);
+        verify(ec2Fleet, never()).modify(any(String.class), any(String.class), any(String.class), any(String.class), anyInt(), anyInt(), anyInt());
+        verify(jenkins, never()).addNode(any(Node.class));
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -902,7 +902,12 @@ public class EC2FleetCloudTest {
         doNothing().when(jenkins).addNode(any(Node.class));
 
         // when
-        fleetCloud.provision(null, 10);
+        Collection<NodeProvisioner.PlannedNode> plannedNodes = fleetCloud.provision(null, 10);
+        Assert.assertEquals(10, plannedNodes.size());
+        for (NodeProvisioner.PlannedNode plannedNode : plannedNodes) {
+            Assert.assertFalse(plannedNode.future.isCancelled());
+        }
+
         // try to modify and reset to add
         fleetCloud.update();
         // reset to old empty state
@@ -912,9 +917,12 @@ public class EC2FleetCloudTest {
         // then
         // should reset list to empty
         Assert.assertEquals(0, fleetCloud.getPlannedNodesCache().size());
+        // make sure all trimmed planned nodes were cancelled
+        Assert.assertEquals(10, plannedNodes.size());
+        for (NodeProvisioner.PlannedNode plannedNode : plannedNodes) {
+            Assert.assertTrue("Planned node should be cancelled", plannedNode.future.isCancelled());
+        }
     }
-
-    // todo check that trimmed were cancelled
 
     @Test
     public void update_shouldUpdateStateWithFleetTargetCapacityPlusToAdd() throws IOException {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
@@ -1,0 +1,132 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import hudson.slaves.Cloud;
+import hudson.widgets.Widget;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(EC2FleetStatusWidgetUpdater.class)
+public class EC2FleetStatusWidgetUpdaterTest {
+
+    @Mock
+    private EC2FleetCloud cloud1;
+
+    @Mock
+    private EC2FleetCloud cloud2;
+
+    @Mock
+    private EC2FleetStatusWidget widget1;
+
+    @Mock
+    private EC2FleetStatusWidget widget2;
+
+    private List<Widget> widgets = new ArrayList<>();
+
+    private List<Cloud> clouds = new ArrayList<>();
+
+    private FleetStateStats stats1 = new FleetStateStats(
+            "f1", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+
+    private FleetStateStats stats2 = new FleetStateStats(
+            "f2", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+
+    @Before
+    public void before() throws Exception {
+        PowerMockito.mockStatic(EC2FleetStatusWidgetUpdater.class);
+        PowerMockito.when(EC2FleetStatusWidgetUpdater.class, "getClouds").thenReturn(clouds);
+        PowerMockito.when(EC2FleetStatusWidgetUpdater.class, "getWidgets").thenReturn(widgets);
+
+        when(cloud1.getLabelString()).thenReturn("a");
+        when(cloud2.getLabelString()).thenReturn("");
+        when(cloud1.getFleet()).thenReturn("f1");
+        when(cloud2.getFleet()).thenReturn("f2");
+
+        when(cloud1.getStats()).thenReturn(stats1);
+        when(cloud2.getStats()).thenReturn(stats2);
+    }
+
+    private EC2FleetStatusWidgetUpdater getMockEC2FleetStatusWidgetUpdater() {
+        return Whitebox.newInstance(EC2FleetStatusWidgetUpdater.class);
+    }
+
+    @Test
+    public void shouldDoNothingIfNoCloudsAndWidgets() {
+        getMockEC2FleetStatusWidgetUpdater().doRun();
+    }
+
+    @Test
+    public void shouldDoNothingIfNoWidgets() {
+        clouds.add(cloud1);
+        clouds.add(cloud2);
+
+        getMockEC2FleetStatusWidgetUpdater().doRun();
+
+        verifyZeroInteractions(widget1, widget2);
+    }
+
+    @Test
+    public void shouldIgnoreNonEC2FleetClouds() {
+        clouds.add(cloud1);
+
+        Cloud nonEc2FleetCloud = mock(Cloud.class);
+        clouds.add(nonEc2FleetCloud);
+
+        widgets.add(widget2);
+
+        getMockEC2FleetStatusWidgetUpdater().doRun();
+
+        verify(cloud1).getStats();
+        verifyZeroInteractions(nonEc2FleetCloud);
+    }
+
+    @Test
+    public void shouldUpdateCloudCollectAllResultAndUpdateWidgets() {
+        clouds.add(cloud1);
+        clouds.add(cloud2);
+
+        widgets.add(widget1);
+
+        getMockEC2FleetStatusWidgetUpdater().doRun();
+
+        verify(widget1).setStatusList(ImmutableList.of(
+                new EC2FleetStatusInfo(cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired()),
+                new EC2FleetStatusInfo(cloud2.getFleet(), stats2.getState().getDetailed(), cloud2.getLabelString(), stats2.getNumActive(), stats2.getNumDesired())
+        ));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void shouldIgnoreNonEc2FleetWidgets() {
+        clouds.add(cloud1);
+
+        Widget nonEc2FleetWidget = mock(Widget.class);
+        widgets.add(nonEc2FleetWidget);
+
+        widgets.add(widget1);
+
+        getMockEC2FleetStatusWidgetUpdater().doRun();
+
+        verify(widget1).setStatusList(any(List.class));
+        verifyZeroInteractions(nonEc2FleetWidget);
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
@@ -44,10 +44,10 @@ public class EC2FleetStatusWidgetUpdaterTest {
     private List<Cloud> clouds = new ArrayList<>();
 
     private FleetStateStats stats1 = new FleetStateStats(
-            "f1", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f1", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
 
     private FleetStateStats stats2 = new FleetStateStats(
-            "f2", 1, new FleetStateStats.State(true, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f2", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
 
     @Before
     public void before() throws Exception {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -48,6 +48,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -233,6 +234,12 @@ public abstract class IntegrationTest {
     protected static Set<String> labelsToNames(Set<Label> labels) {
         Set<String> r = new HashSet<>();
         for (Label l : labels) r.add(l.getName());
+        return r;
+    }
+
+    protected static Set<String> nodeToNames(Collection<Node> nodes) {
+        Set<String> r = new HashSet<>();
+        for (Node l : nodes) r.add(l.getNodeName());
         return r;
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/IntegrationTest.java
@@ -408,7 +408,7 @@ public abstract class IntegrationTest {
                 }
 
                 return new FleetStateStats("", 0,
-                        new FleetStateStats.State(true, "active"),
+                        new FleetStateStats.State(true, false, "active"),
                         instanceIds, Collections.<String, Double>emptyMap());
             }
         });


### PR DESCRIPTION
### Bugfixes
1. Handle EC2 Spot Fleet ```modifying``` state correctly. Due to the implementation of each modification of fleet not applied immediately and required some time during which ```targetCapacity``` is old. EC2 Spot Fleet [Lifecycle](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet-requests.html#spot-fleet-states)
   - #156
1. Avoid negative target capacity if fleet updated outside of plugin (a few other cases)
1. Fix widget information
   - #147 