### PR TITLE
Label based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ automatically scaling the capacity with the load.
   * [Scaling](#scaling)
   * [Groovy](#groovy)
   * [Preconfigure Slave](#preconfigure-slave)
+  * [Label Based Configuration (beta)](docs/LABEL-BASED-CONFIGURATION.md)
 * [Development](#development)
 
 # Overview
@@ -36,6 +37,7 @@ the fleet within the specified price range. For more information, see
 - Allow no delay scale up strategy, enable ```No Delay Provision Strategy``` in configuration
 - Add tags to EC2 instances used by plugin, for easy search, tag format ```ec2-fleet-plugin:cloud-name=<MyCloud>```
 - Allow custom EC2 API endpoint
+- Auto Fleet creation based on Job label [see](docs/LABEL-BASED-CONFIGURATION.md)
 
 # Change Log
 

--- a/docs/LABEL-BASED-CONFIGURATION.md
+++ b/docs/LABEL-BASED-CONFIGURATION.md
@@ -14,8 +14,8 @@ Feature in *beta* mode. Please report all problem [here](https://github.com/jenk
 This feature auto manages EC2 Spot Fleet or ASG based Fleets for Jenkins based on 
 label attached to Jenkins Jobs.
 
-With this feature user of EC2 Fleet Plugin don't need to pre-create AWS resources 
-before start configuration and run Jobs. Plugin required just AWS Credentials 
+With this feature user of EC2 Fleet Plugin doesn't need to have pre-created AWS resources 
+to start configuration and run Jobs. Plugin required just AWS Credentials 
 with permissions to be able create resources.
 
 # How It Works

--- a/docs/LABEL-BASED-CONFIGURATION.md
+++ b/docs/LABEL-BASED-CONFIGURATION.md
@@ -33,6 +33,8 @@ Label format
 
 # Supported Parameters
 
+*Note* Parameter name is case insensitive
+
 | Parameter | Value Example | Value |      
 | --- | ---| ---- |
 | imageId | ```ami-0080e4c5bc078760e``` | *Required* AMI ID https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html |

--- a/docs/LABEL-BASED-CONFIGURATION.md
+++ b/docs/LABEL-BASED-CONFIGURATION.md
@@ -1,0 +1,92 @@
+[Back to README](../README.md)
+
+# Label Based Configuration
+
+* [Overview](#overview)
+* [How it works](#how-it-works)
+* [Supported Parameters](#supported-parameters)
+* [Configuration](#configuration)
+
+# Overview
+
+Feature in *beta* mode. Please report all problem [here](https://github.com/jenkinsci/ec2-fleet-plugin/issues/new)
+
+This feature auto manages EC2 Spot Fleet or ASG based Fleets for Jenkins based on 
+label attached to Jenkins Jobs.
+
+With this feature user of EC2 Fleet Plugin don't need to pre-create AWS resources 
+before start configuration and run Jobs. Plugin required just AWS Credentials 
+with permissions to be able create resources.
+
+# How It Works
+
+- Plugin detects all labeled Jobs where Label starts from Name configured in plugin configuration ```Cloud Name```
+- Plugin parses Label to get Fleet configuration
+- Plugin creates dedicated fleet for each unique Label
+  - Plugin uses [CloudFormation Stacks](https://aws.amazon.com/cloudformation/) to provision Fleet and all required resources
+- When Label is not used by any Job Plugin deletes Stack and release resources  
+
+Label format
+```
+<CloudName>_parameter1=value1,parameter2=value2
+```
+
+# Supported Parameters
+
+| Parameter | Value Example | Value |      
+| --- | ---| ---- |
+| imageId | ```ami-0080e4c5bc078760e``` | *Required* AMI ID https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html |
+| max | ```12``` | Fleet Max Size, positive value or zero. If not specified plugin configuration Max will be used |
+| min | ```1``` | Fleet Min Size, positive value or zero. If not specified plugin configuration Min will be used |
+| instanceType | ```c4.large``` | EC2 Instance Type https://aws.amazon.com/ec2/instance-types/. If not specified ```m4.large``` will be used |
+| spotPrice | ```0.4``` | Max Spot Price, if not specified EC2 Spot Fleet API will use default price. |
+
+### Examples
+
+Minimum configuration just Image ID
+```
+<FleetName>_imageId=ami-0080e4c5bc078760e
+```
+
+# Configuration
+
+1. Create AWS User
+1. Add Inline User Permissions
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [{
+        "Effect": "Allow",
+        "Action": [
+            "cloudformation:*",
+            "ec2:*",
+            "autoscaling:*",
+            "iam:ListRoles",
+            "iam:PassRole",
+            "iam:ListInstanceProfiles",
+            "iam:CreateRole",
+            "iam:AttachRolePolicy",
+            "iam:GetRole"
+        ],
+        "Resource": "*"
+    }]
+}
+```
+1. Goto ```Manage Jenkins > Configure Jenkins```
+1. Add Cloud ```Amazon EC2 Fleet label based```
+1. Specify ```AWS Credentials```
+1. Specify ```SSH Credentials```
+   - Jenkins need to be able to connect to EC2 Instances to run Jobs
+1. Set ```Region```
+1. Provide base configuration
+   - Note ```Cloud Name```
+1. Goto to Jenkins Job which you want to run on this Fleet
+  1. Goto Job ```Configuration```
+  1. Enable ```Restrict where this project can be run```
+  1. Set Label value to ```<Cloud Name>_parameterName=paremeterValue,p2=v2``` 
+  1. Click ```Save```
+  
+In some short time plugin will detect Job and will create required resources to be able 
+run it in future.  
+  
+That's all, you can repeat this for other Jobs.

--- a/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
@@ -1,0 +1,21 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.slaves.Cloud;
+
+public abstract class AbstractEC2FleetCloud extends Cloud {
+
+    protected AbstractEC2FleetCloud(String name) {
+        super(name);
+    }
+
+    public abstract boolean isDisableTaskResubmit();
+
+    public abstract int getIdleMinutes();
+
+    public abstract boolean isAlwaysReconnect();
+
+    public abstract boolean scheduleToTerminate(String instanceId);
+
+    public abstract String getOldId();
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
@@ -1,0 +1,133 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.AmazonCloudFormationClient;
+import com.amazonaws.services.cloudformation.model.Capability;
+import com.amazonaws.services.cloudformation.model.CreateStackRequest;
+import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksRequest;
+import com.amazonaws.services.cloudformation.model.DescribeStacksResult;
+import com.amazonaws.services.cloudformation.model.Parameter;
+import com.amazonaws.services.cloudformation.model.Stack;
+import com.amazonaws.services.cloudformation.model.StackStatus;
+import com.amazonaws.services.cloudformation.model.Tag;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
+import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
+import jenkins.model.Jenkins;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CloudFormationApi {
+
+    public AmazonCloudFormation connect(final String awsCredentialsId, final String regionName, final String endpoint) {
+        final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration();
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
+        final AmazonCloudFormation client =
+                credentials != null ?
+                        new AmazonCloudFormationClient(credentials, clientConfiguration) :
+                        new AmazonCloudFormationClient(clientConfiguration);
+
+        final String effectiveEndpoint = getEndpoint(regionName, endpoint);
+        if (effectiveEndpoint != null) client.setEndpoint(effectiveEndpoint);
+        return client;
+    }
+
+    // todo do we want to merge with EC2Api#getEndpoint
+    @Nullable
+    private String getEndpoint(@Nullable final String regionName, @Nullable final String endpoint) {
+        if (StringUtils.isNotEmpty(endpoint)) {
+            return endpoint;
+        } else if (StringUtils.isNotEmpty(regionName)) {
+            final Region region = RegionUtils.getRegion(regionName);
+            if (region != null && region.isServiceSupported(endpoint)) {
+                return region.getServiceEndpoint(endpoint);
+            } else {
+                final String domain = regionName.startsWith("cn-") ? "amazonaws.com.cn" : "amazonaws.com";
+                return "https://cloudformation." + regionName + "." + domain;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    public void delete(final AmazonCloudFormation client, final String stackId) {
+        client.deleteStack(new DeleteStackRequest().withStackName(stackId));
+    }
+
+    public void create(
+            final AmazonCloudFormation client, final String fleetName, final String keyName, final String parametersString) {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters(parametersString);
+
+        try {
+            final String type = parameters.getOrDefault("type", "ec2-spot-fleet");
+            final String imageId = parameters.get("imageId"); //"ami-0080e4c5bc078760e";
+            final int maxSize = parameters.getIntOrDefault("maxSize", 10);
+            final int minSize = parameters.getIntOrDefault("minSize", 0);
+            final String instanceType = parameters.getOrDefault("instanceType", "m4.large");
+            final String spotPrice = parameters.get("spotPrice"); // "0.04"
+
+            final String template = "/com/amazon/jenkins/ec2fleet/" + (type.equals("asg") ? "auto-scaling-group.yml" : "ec2-spot-fleet.yml");
+            client.createStack(
+                    new CreateStackRequest()
+                            .withStackName(fleetName + "-" + System.currentTimeMillis())
+                            .withTags(
+                                    new Tag().withKey("ec2-fleet-plugin")
+                                            .withValue(parametersString)
+                            )
+                            .withTemplateBody(IOUtils.toString(CloudFormationApi.class.getResourceAsStream(template)))
+                            // to allow some of templates create iam
+                            .withCapabilities(Capability.CAPABILITY_IAM)
+                            .withParameters(
+                                    new Parameter().withParameterKey("ImageId").withParameterValue(imageId),
+                                    new Parameter().withParameterKey("InstanceType").withParameterValue(instanceType),
+                                    new Parameter().withParameterKey("MaxSize").withParameterValue(Integer.toString(maxSize)),
+                                    new Parameter().withParameterKey("MinSize").withParameterValue(Integer.toString(minSize)),
+                                    new Parameter().withParameterKey("SpotPrice").withParameterValue(spotPrice),
+                                    new Parameter().withParameterKey("KeyName").withParameterValue(keyName)
+                            ));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class StackInfo {
+        public final String stackId;
+        public final String fleetId;
+        public final StackStatus stackStatus;
+
+        public StackInfo(String stackId, String fleetId, StackStatus stackStatus) {
+            this.stackId = stackId;
+            this.fleetId = fleetId;
+            this.stackStatus = stackStatus;
+        }
+    }
+
+    public Map<String, StackInfo> describe(
+            final AmazonCloudFormation client, final String fleetName) {
+        Map<String, StackInfo> r = new HashMap<>();
+
+        String nextToken = null;
+        do {
+            DescribeStacksResult describeStacksResult = client.describeStacks(
+                    new DescribeStacksRequest().withNextToken(nextToken));
+            for (Stack stack : describeStacksResult.getStacks()) {
+                if (stack.getStackName().startsWith(fleetName)) {
+                    final String fleetId = stack.getOutputs().isEmpty() ? null : stack.getOutputs().get(0).getOutputValue();
+                    r.put(stack.getTags().get(0).getValue(), new StackInfo(
+                            stack.getStackId(), fleetId, StackStatus.valueOf(stack.getStackStatus())));
+                }
+            }
+            nextToken = describeStacksResult.getNextToken();
+        } while (nextToken != null);
+
+        return r;
+    }
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -125,7 +126,7 @@ public class EC2Api {
      * @param ec2 ec2 client
      * @param instanceIds set of instance ids
      */
-    public void terminateInstances(final AmazonEC2 ec2, final Set<String> instanceIds) {
+    public void terminateInstances(final AmazonEC2 ec2, final Collection<String> instanceIds) {
         final List<String> temp = new ArrayList<>(instanceIds);
         while (temp.size() > 0) {
             // terminateInstances is idempotent so it can be called until it's successful

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -78,7 +78,7 @@ public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLaun
         if (computer == null) return;
 
         // in some multi-thread edge cases cloud could be null for some time, just be ok with that
-        final EC2FleetCloud cloud = ((EC2FleetNodeComputer) computer).getCloud();
+        final AbstractEC2FleetCloud cloud = ((EC2FleetNodeComputer) computer).getCloud();
         if (cloud == null) {
             LOGGER.warning("Edge case cloud is null for computer " + computer.getDisplayName()
                     + " should be autofixed in a few minutes, if no please create issue for plugin");

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -52,7 +52,7 @@ import java.util.logging.SimpleFormatter;
  * @see CloudNanny
  */
 @SuppressWarnings({"unused", "WeakerAccess"})
-public class EC2FleetCloud extends Cloud {
+public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
     public static final String EC2_INSTANCE_TAG_NAMESPACE = "ec2-fleet-plugin";
     public static final String EC2_INSTANCE_CLOUD_NAME_TAG = EC2_INSTANCE_TAG_NAMESPACE + ":cloud-name";
@@ -692,6 +692,7 @@ public class EC2FleetCloud extends Cloud {
         // jenkins automatically remove old node with same name if any
         jenkins.addNode(node);
 
+        // todo use plannedNodesCache in thread-safe way
         final SettableFuture<Node> future;
         if (plannedNodesCache.isEmpty()) {
             future = SettableFuture.create();

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudAware.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudAware.java
@@ -16,8 +16,8 @@ import javax.annotation.Nonnull;
  */
 public interface EC2FleetCloudAware {
 
-    EC2FleetCloud getCloud();
+    AbstractEC2FleetCloud getCloud();
 
-    void setCloud(@Nonnull EC2FleetCloud cloud);
+    void setCloud(@Nonnull AbstractEC2FleetCloud cloud);
 
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudAwareUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudAwareUtils.java
@@ -15,7 +15,7 @@ public class EC2FleetCloudAwareUtils {
 
     private static final Logger LOGGER = Logger.getLogger(EC2FleetCloudAwareUtils.class.getName());
 
-    public static void reassign(final @Nonnull String oldId, @Nonnull final EC2FleetCloud cloud) {
+    public static void reassign(final @Nonnull String oldId, @Nonnull final AbstractEC2FleetCloud cloud) {
         for (final Computer computer : Jenkins.getActiveInstance().getComputers()) {
             checkAndReassign(oldId, cloud, computer);
         }
@@ -27,10 +27,10 @@ public class EC2FleetCloudAwareUtils {
         LOGGER.info("Finish to reassign resources from old cloud with id " + oldId + " to " + cloud.getDisplayName());
     }
 
-    private static void checkAndReassign(final String oldId, final EC2FleetCloud cloud, final Object object) {
+    private static void checkAndReassign(final String oldId, final AbstractEC2FleetCloud cloud, final Object object) {
         if (object instanceof EC2FleetCloudAware) {
             final EC2FleetCloudAware cloudAware = (EC2FleetCloudAware) object;
-            final EC2FleetCloud oldCloud = cloudAware.getCloud();
+            final AbstractEC2FleetCloud oldCloud = cloudAware.getCloud();
             if (oldCloud != null && oldId.equals(oldCloud.getOldId())) {
                 ((EC2FleetCloudAware) object).setCloud(cloud);
                 LOGGER.info("Reassign " + object + " from " + oldCloud.getDisplayName() + " to " + cloud.getDisplayName());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -1,0 +1,910 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazon.jenkins.ec2fleet.fleet.EC2Fleets;
+import com.amazon.jenkins.ec2fleet.fleet.EC2SpotFleet;
+import com.amazonaws.regions.RegionUtils;
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.model.StackStatus;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.DescribeRegionsResult;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceStateName;
+import com.amazonaws.services.ec2.model.KeyPairInfo;
+import com.amazonaws.services.ec2.model.Region;
+import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
+import com.google.common.util.concurrent.SettableFuture;
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.model.Computer;
+import hudson.model.Descriptor;
+import hudson.model.Item;
+import hudson.model.Label;
+import hudson.model.Node;
+import hudson.model.Queue;
+import hudson.model.TaskListener;
+import hudson.slaves.Cloud;
+import hudson.slaves.ComputerConnector;
+import hudson.slaves.NodeProperty;
+import hudson.slaves.NodeProvisioner;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+/**
+ * @see CloudNanny
+ */
+@SuppressWarnings({"unused", "WeakerAccess"})
+public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
+
+    public static final String EC2_INSTANCE_TAG_NAMESPACE = "ec2-fleet-plugin";
+    public static final String EC2_INSTANCE_CLOUD_NAME_TAG = EC2_INSTANCE_TAG_NAMESPACE + ":cloud-name";
+
+    public static final String FLEET_CLOUD_ID = "FleetCloudLabel";
+
+    public static final int DEFAULT_CLOUD_STATUS_INTERVAL_SEC = 10;
+
+    private static final int DEFAULT_INIT_ONLINE_TIMEOUT_SEC = 3 * 60;
+    private static final int DEFAULT_INIT_ONLINE_CHECK_INTERVAL_SEC = 15;
+
+//    private static final String NEW_EC2_KEY_PAIR_VALUE = "- New Key Pair -";
+
+    private static final SimpleFormatter sf = new SimpleFormatter();
+    private static final Logger LOGGER = Logger.getLogger(EC2FleetLabelCloud.class.getName());
+
+    /**
+     * Provide unique identifier for this instance of {@link EC2FleetLabelCloud}, <code>transient</code>
+     * will not be stored. Not available for customer, instead use {@link EC2FleetLabelCloud#name}
+     * will be used only during Jenkins configuration update <code>config.jelly</code>,
+     * when new instance of same cloud is created and we need to find old instance and
+     * repoint resources like {@link Computer} {@link Node} etc.
+     * <p>
+     * It's lazy to support old versions which don't have this field at all.
+     * <p>
+     * However it's stable, as soon as it will be created and called first uuid will be same
+     * for all future calls to the same instances of lazy uuid.
+     *
+     * @see EC2FleetCloudAware
+     */
+    private transient LazyUuid id;
+
+    private final String awsCredentialsId;
+    private final String region;
+    private final String endpoint;
+
+    private final String fsRoot;
+    private final ComputerConnector computerConnector;
+    private final boolean privateIpUsed;
+    private final boolean alwaysReconnect;
+    private final Integer idleMinutes;
+    private final Integer minSize;
+    private final Integer maxSize;
+    private final Integer numExecutors;
+    private final boolean restrictUsage;
+    private final Integer initOnlineTimeoutSec;
+    private final Integer initOnlineCheckIntervalSec;
+    private final Integer cloudStatusIntervalSec;
+    private final String ec2KeyPairName;
+
+    /**
+     * @see EC2FleetAutoResubmitComputerLauncher
+     */
+    private final boolean disableTaskResubmit;
+
+    /**
+     * @see NoDelayProvisionStrategy
+     */
+    private final boolean noDelayProvision;
+
+    private transient Map<String, State> states;
+
+    @DataBoundConstructor
+    public EC2FleetLabelCloud(final String name,
+                              final String oldId,
+                              final String awsCredentialsId,
+                              final String region,
+                              final String endpoint,
+                              final String fleet,
+                              final String labelString,
+                              final String fsRoot,
+                              final ComputerConnector computerConnector,
+                              final boolean privateIpUsed,
+                              final boolean alwaysReconnect,
+                              final Integer idleMinutes,
+                              final Integer minSize,
+                              final Integer maxSize,
+                              final Integer numExecutors,
+                              final boolean restrictUsage,
+                              final boolean disableTaskResubmit,
+                              final Integer initOnlineTimeoutSec,
+                              final Integer initOnlineCheckIntervalSec,
+                              final boolean scaleExecutorsByWeight,
+                              final Integer cloudStatusIntervalSec,
+                              final boolean noDelayProvision,
+                              final String ec2KeyPairName) {
+        super(StringUtils.isBlank(name) ? FLEET_CLOUD_ID : name);
+        init();
+        this.awsCredentialsId = awsCredentialsId;
+        this.region = region;
+        this.endpoint = endpoint;
+        this.fsRoot = fsRoot;
+        this.computerConnector = computerConnector;
+        this.idleMinutes = idleMinutes;
+        this.privateIpUsed = privateIpUsed;
+        this.alwaysReconnect = alwaysReconnect;
+        this.minSize = minSize;
+        this.maxSize = maxSize;
+        this.numExecutors = numExecutors;
+        this.restrictUsage = restrictUsage;
+        this.disableTaskResubmit = disableTaskResubmit;
+        this.initOnlineTimeoutSec = initOnlineTimeoutSec;
+        this.initOnlineCheckIntervalSec = initOnlineCheckIntervalSec;
+        this.cloudStatusIntervalSec = cloudStatusIntervalSec;
+        this.noDelayProvision = noDelayProvision;
+        this.ec2KeyPairName = ec2KeyPairName;
+
+        if (StringUtils.isNotEmpty(oldId)) {
+            // existent cloud was modified, let's re-assign all dependencies of old cloud instance
+            // to new one
+            EC2FleetCloudAwareUtils.reassign(oldId, this);
+        }
+    }
+
+    public String getEc2KeyPairName() {
+        return ec2KeyPairName;
+    }
+
+    public boolean isNoDelayProvision() {
+        return noDelayProvision;
+    }
+
+    public String getAwsCredentialsId() {
+        return awsCredentialsId;
+    }
+
+    /**
+     * Called old as will be used by new instance of cloud, for
+     * which this id is old (not current)
+     *
+     * @return id of current cloud
+     */
+    public String getOldId() {
+        return id.getValue();
+    }
+
+    public boolean isDisableTaskResubmit() {
+        return disableTaskResubmit;
+    }
+
+    public int getInitOnlineTimeoutSec() {
+        return initOnlineTimeoutSec == null ? DEFAULT_INIT_ONLINE_TIMEOUT_SEC : initOnlineTimeoutSec;
+    }
+
+    public int getCloudStatusIntervalSec() {
+        return cloudStatusIntervalSec == null ? DEFAULT_CLOUD_STATUS_INTERVAL_SEC : cloudStatusIntervalSec;
+    }
+
+    public int getInitOnlineCheckIntervalSec() {
+        return initOnlineCheckIntervalSec == null ? DEFAULT_INIT_ONLINE_CHECK_INTERVAL_SEC : initOnlineCheckIntervalSec;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public String getFsRoot() {
+        return fsRoot;
+    }
+
+    public ComputerConnector getComputerConnector() {
+        return computerConnector;
+    }
+
+    public boolean isPrivateIpUsed() {
+        return privateIpUsed;
+    }
+
+    public boolean isAlwaysReconnect() {
+        return alwaysReconnect;
+    }
+
+    public int getIdleMinutes() {
+        return (idleMinutes != null) ? idleMinutes : 0;
+    }
+
+    public Integer getMaxSize() {
+        return maxSize;
+    }
+
+    public Integer getMinSize() {
+        return minSize;
+    }
+
+    public Integer getNumExecutors() {
+        return numExecutors;
+    }
+
+    public String getJvmSettings() {
+        return "";
+    }
+
+    public boolean isRestrictUsage() {
+        return restrictUsage;
+    }
+
+//    @VisibleForTesting
+//    synchronized Set<NodeProvisioner.PlannedNode> getPlannedNodesCache() {
+//        return plannedNodesCache;
+//    }
+
+//    @VisibleForTesting
+//    synchronized Set<String> getInstanceIdsToTerminate() {
+//        return instanceIdsToTerminate;
+//    }
+
+//    @VisibleForTesting
+//    synchronized int getToAdd() {
+//        return toAdd;
+//    }
+
+//    @VisibleForTesting
+//    synchronized FleetStateStats getStats() {
+//        return stats;
+//    }
+
+//    @VisibleForTesting
+//    synchronized void setStats(final FleetStateStats stats) {
+//        this.stats = stats;
+//    }
+
+    @Override
+    public synchronized Collection<NodeProvisioner.PlannedNode> provision(final Label label, int excessWorkload) {
+        info("excessWorkload %s", excessWorkload);
+
+        List<NodeProvisioner.PlannedNode> r = new ArrayList<>();
+
+        for (Map.Entry<String, State> state : states.entrySet()) {
+            if (Label.parse(state.getKey()).containsAll(label.listAtoms())) {
+                LOGGER.info("provision " + label + " excessWorkload " + excessWorkload);
+
+                final FleetStateStats stats = state.getValue().stats;
+                final int cap = stats.getNumDesired() + state.getValue().toAdd;
+
+                if (!stats.getState().isActive()) {
+                    info("fleet in %s not active state", stats.getState().getDetailed());
+                    continue;
+                }
+
+                final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters(state.getKey());
+
+                final int maxSize = parameters.getIntOrDefault("maxSize", this.maxSize);
+                if (cap >= maxSize) {
+                    info("max %s reached, no more provision", maxSize);
+                    continue;
+                }
+
+                // if the planned node has 0 executors configured force it to 1 so we end up doing an unweighted check
+                final int numExecutors1 = Math.max(parameters.getIntOrDefault("numExecutors", numExecutors), 1);
+
+                // Calculate the ceiling, without having to work with doubles from Math.ceil
+                // https://stackoverflow.com/a/21830188/877024
+                final int weightedExcessWorkload = (excessWorkload + numExecutors1 - 1) / numExecutors1;
+                int targetCapacity = Math.min(cap + weightedExcessWorkload, maxSize);
+
+                int toProvision = targetCapacity - cap;
+                info("to provision = %s", toProvision);
+
+                if (toProvision < 1) return Collections.emptyList();
+
+                state.getValue().toAdd += toProvision;
+
+                for (int f = 0; f < toProvision; ++f) {
+                    // todo make name unique per fleet
+                    final NodeProvisioner.PlannedNode plannedNode = new NodeProvisioner.PlannedNode(
+                            "FleetNode-" + r.size(), SettableFuture.<Node>create(), this.numExecutors);
+                    r.add(plannedNode);
+                    state.getValue().plannedNodes.add(plannedNode);
+                }
+            }
+        }
+
+        return r;
+    }
+
+    private static class State {
+        final String fleetId;
+        FleetStateStats stats;
+        int targetCapacity;
+        int toAdd;
+        final Set<NodeProvisioner.PlannedNode> plannedNodes;
+        final Set<NodeProvisioner.PlannedNode> plannedNodesToRemove;
+        final Set<String> instanceIdsToTerminate;
+
+        public State(String fleetId) {
+            this.fleetId = fleetId;
+            this.plannedNodes = new HashSet<>();
+            this.plannedNodesToRemove = new HashSet<>();
+            this.instanceIdsToTerminate = new HashSet<>();
+        }
+
+        public State(State state) {
+            this.plannedNodes = new HashSet<>(state.plannedNodes);
+            this.fleetId = state.fleetId;
+            this.stats = state.stats;
+            this.targetCapacity = state.targetCapacity;
+            this.toAdd = state.toAdd;
+            this.plannedNodesToRemove = new HashSet<>(state.plannedNodesToRemove);
+            this.instanceIdsToTerminate = new HashSet<>(state.instanceIdsToTerminate);
+        }
+    }
+
+    public void update() {
+        info("start");
+
+        final Map<String, State> currentStates;
+        synchronized (this) {
+            currentStates = new HashMap<>();
+            for (Map.Entry<String, State> state : states.entrySet()) {
+                currentStates.put(state.getKey(), new State(state.getValue()));
+            }
+        }
+
+        final Set<String> fleetIds = new HashSet<>();
+        for (State state : states.values()) fleetIds.add(state.fleetId);
+        final Map<String, FleetStateStats> currentStats = new EC2SpotFleet().getStateBatch(
+                getAwsCredentialsId(), region, endpoint, fleetIds);
+        for (State state : currentStates.values()) {
+            // todo what if we don't find this fleet in map
+            state.stats = currentStats.get(state.fleetId);
+
+            state.targetCapacity = Math.max(0,
+                    state.stats.getNumDesired() - state.instanceIdsToTerminate.size() + state.toAdd);
+            state.stats = new FleetStateStats(state.stats, state.targetCapacity);
+        }
+
+        updateByState(currentStates);
+
+        synchronized (this) {
+            for (Map.Entry<String, State> entry : currentStates.entrySet()) {
+                final State state = states.get(entry.getKey());
+
+                state.stats = entry.getValue().stats;
+                state.instanceIdsToTerminate.removeAll(entry.getValue().instanceIdsToTerminate);
+                // toAdd only grow outside of this method, so we can subtract
+                state.toAdd = state.toAdd - entry.getValue().toAdd;
+                // remove released planned nodes
+                state.plannedNodes.removeAll(entry.getValue().plannedNodesToRemove);
+                // limit planned pool according to real target capacity
+                while (state.plannedNodes.size() > entry.getValue().targetCapacity) {
+                    final Iterator<NodeProvisioner.PlannedNode> iterator = state.plannedNodes.iterator();
+                    final NodeProvisioner.PlannedNode plannedNodeToCancel = iterator.next();
+                    iterator.remove();
+                    // cancel to let jenkins no that node is not valid any more
+                    plannedNodeToCancel.future.cancel(true);
+                }
+            }
+        }
+    }
+
+    private void updateByState(final Map<String, State> states) {
+        final Jenkins jenkins = Jenkins.getActiveInstance();
+
+        final AmazonEC2 ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
+
+        for (State state : states.values()) {
+            if (state.toAdd > 0 || state.instanceIdsToTerminate.size() > 0) {
+                // todo fix negative value
+                // we do update any time even real capacity was not update like remove one add one to
+                // update fleet settings with NoTermination so we can terminate instances on our own
+                EC2Fleets.get(state.fleetId).modify(
+                        getAwsCredentialsId(), region, endpoint, state.fleetId, state.targetCapacity, minSize, maxSize);
+                info("Update fleet target capacity to %s", state.targetCapacity);
+            }
+        }
+
+        final List<String> instanceIdsToRemove = new ArrayList<>();
+        for (State state : states.values()) {
+            instanceIdsToRemove.addAll(state.instanceIdsToTerminate);
+        }
+
+        if (instanceIdsToRemove.size() > 0) {
+            // internally removeNode lock on queue to correctly update node list
+            // we do big block for all removal to avoid delay on lock waiting
+            // for each node
+            Queue.withLock(new Runnable() {
+                @Override
+                public void run() {
+                    for (final String instanceId : instanceIdsToRemove) {
+                        final Node node = jenkins.getNode(instanceId);
+                        if (node != null) {
+                            try {
+                                jenkins.removeNode(node);
+                            } catch (IOException e) {
+                                warning("unable remove node %s from Jenkins, skip, just terminate EC2 instance", instanceId);
+                            }
+                        }
+                    }
+                }
+            });
+            info("Delete terminating nodes from Jenkins %s", instanceIdsToRemove);
+
+            Registry.getEc2Api().terminateInstances(ec2, instanceIdsToRemove);
+            info("Instances %s were terminated with result", instanceIdsToRemove);
+        }
+
+        for (final Map.Entry<String, State> entry : states.entrySet()) {
+            final State state = entry.getValue();
+            info("fleet instances %s", state.stats.getInstances());
+
+            // Set up the lists of Jenkins nodes and fleet instances
+            // currentFleetInstances contains instances currently in the fleet
+            final Set<String> fleetInstances = new HashSet<>(state.stats.getInstances());
+
+            final Map<String, Instance> described = Registry.getEc2Api().describeInstances(ec2, fleetInstances);
+            info("described instances %s", described.keySet());
+
+            // currentJenkinsNodes contains all registered Jenkins nodes related to this cloud
+            final Set<String> jenkinsInstances = new HashSet<>();
+            for (final Node node : jenkins.getNodes()) {
+                if (node instanceof EC2FleetNode) {
+                    final EC2FleetNode node1 = (EC2FleetNode) node;
+                    // cloud and label are same
+                    if (node1.getCloud() == this && node1.getLabelString().equals(entry.getKey())) {
+                        jenkinsInstances.add(node.getNodeName());
+                    }
+                }
+            }
+            info("jenkins nodes %s", jenkinsInstances);
+
+            // contains Jenkins nodes that were once fleet instances but are no longer in the fleet
+            final Set<String> jenkinsNodesWithInstance = new HashSet<>(jenkinsInstances);
+            jenkinsNodesWithInstance.removeAll(fleetInstances);
+            info("jenkins nodes without instance %s", jenkinsNodesWithInstance);
+
+            // terminatedFleetInstances contains fleet instances that are terminated, stopped, stopping, or shutting down
+            final Set<String> terminatedFleetInstances = new HashSet<>(fleetInstances);
+            // terminated are any current which cannot be described
+            terminatedFleetInstances.removeAll(described.keySet());
+            info("terminated instances " + terminatedFleetInstances);
+
+            // newFleetInstances contains running fleet instances that are not already Jenkins nodes
+            final Map<String, Instance> newFleetInstances = new HashMap<>(described);
+            for (final String instanceId : jenkinsInstances) newFleetInstances.remove(instanceId);
+            info("new instances " + newFleetInstances.keySet());
+
+            // update caches
+            final List<String> jenkinsNodesToRemove = new ArrayList<>();
+            jenkinsNodesToRemove.addAll(terminatedFleetInstances);
+            jenkinsNodesToRemove.addAll(jenkinsNodesWithInstance);
+            // Remove dying fleet instances from Jenkins
+            for (final String instance : jenkinsNodesToRemove) {
+//                info("Fleet (" + getLabelString() + ") no longer has the instance " + instance + ", removing from Jenkins.");
+                JenkinsUtils.removeNode(instance);
+            }
+
+            // Update the label for all Jenkins nodes in the fleet instance cache
+//            for (final String instanceId : jenkinsInstances) {
+//                final Node node = jenkins.getNode(instanceId);
+//                if (node == null) continue;
+//
+//                if (!labelString.equals(node.getLabelString())) {
+//                    try {
+//                        info("Updating label on node %s to \"%s\".", instanceId, labelString);
+//                        node.setLabelString(labelString);
+//                    } catch (final Exception ex) {
+//                        warning(ex, "Unable to set label on node %s", instanceId);
+//                    }
+//                }
+//            }
+
+            // If we have new instances - create nodes for them!
+            if (newFleetInstances.size() > 0) {
+                // we tag new instances to help users to identify instances launched from plugin managed fleets
+                // if failed we are fine to skip this call
+                try {
+                    Registry.getEc2Api().tagInstances(ec2, newFleetInstances.keySet(),
+                            EC2_INSTANCE_CLOUD_NAME_TAG, name);
+                } catch (final Exception e) {
+                    warning(e, "failed to tag new instances %s, skip", newFleetInstances.keySet());
+                }
+
+                // addNewSlave will call addNode which call queue lock
+                // we speed up this by getting one lock for all nodes to all
+                Queue.withLock(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            for (final Instance instance : newFleetInstances.values()) {
+                                addNewSlave(ec2, instance, entry.getKey(), state);
+                            }
+                        } catch (final Exception ex) {
+                            warning(ex, "Unable to set label on node");
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    public synchronized boolean scheduleToTerminate(final String instanceId) {
+        info("Attempting to terminate instance: %s", instanceId);
+
+        final Node node = Jenkins.getActiveInstance().getNode(instanceId);
+        if (node == null) return false;
+
+        final State state = states.get(node.getLabelString());
+        if (state == null) {
+            info("Skip termination, unknown label " + node.getLabelString() + " for node " + instanceId);
+            return false;
+        }
+
+        // We can't remove instances beyond minSize
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters(node.getLabelString());
+        final int minSize = parameters.getIntOrDefault("minSize", this.minSize);
+        if (minSize > 0 && state.stats.getNumDesired() - state.instanceIdsToTerminate.size() <= minSize) {
+            info("Not terminating %s because we need a minimum of %s instances running.", instanceId, minSize);
+            return false;
+        }
+
+        state.instanceIdsToTerminate.add(instanceId);
+        return true;
+    }
+
+    // sync as we are using modifyable state
+    @Override
+    public synchronized boolean canProvision(final Label label) {
+        for (String labelString : states.keySet()) {
+            final boolean r = label == null || Label.parse(labelString).containsAll(label.listAtoms());
+            fine("CanProvision called on fleet: \"" + labelString + "\" wanting: \"" + (label == null ? "(unspecified)" : label.getName()) + "\". Returning " + r + ".");
+            if (r) return true;
+        }
+        return false;
+    }
+
+    private Object readResolve() {
+        init();
+        return this;
+    }
+
+    private void init() {
+        id = new LazyUuid();
+        states = new HashMap<>();
+    }
+
+    private void addNewSlave(
+            final AmazonEC2 ec2, final Instance instance, final String labelString, final State state) throws Exception {
+        final String instanceId = instance.getInstanceId();
+
+        // instance state check enabled and not running, skip adding
+        if (InstanceStateName.Running != InstanceStateName.fromValue(instance.getState().getName()))
+            return;
+
+        final String address = privateIpUsed ? instance.getPrivateIpAddress() : instance.getPublicIpAddress();
+        // Check if we have the address to use. Nodes don't get it immediately.
+        if (address == null) {
+            if (!privateIpUsed) {
+                info("%s instance public IP address not assigned, it could take some time or" +
+                        " Spot Request is not configured to assign public IPs", instance.getInstanceId());
+            }
+            return; // wait more time, probably IP address not yet assigned
+        }
+
+        // Generate a random FS root if one isn't specified
+        final String effectiveFsRoot;
+        if (StringUtils.isBlank(fsRoot)) {
+            effectiveFsRoot = "/tmp/jenkins-" + UUID.randomUUID().toString().substring(0, 8);
+        } else {
+            effectiveFsRoot = fsRoot;
+        }
+
+        final Double instanceTypeWeight = state.stats.getInstanceTypeWeights().get(instance.getInstanceType());
+        final int effectiveNumExecutors;
+        // todo add scaleExecutorsByWeight
+        if (instanceTypeWeight != null) {
+            effectiveNumExecutors = (int) Math.max(Math.round(numExecutors * instanceTypeWeight), 1);
+        } else {
+            effectiveNumExecutors = numExecutors;
+        }
+
+        final EC2FleetAutoResubmitComputerLauncher computerLauncher = new EC2FleetAutoResubmitComputerLauncher(
+                computerConnector.launch(address, TaskListener.NULL));
+        final Node.Mode nodeMode = restrictUsage ? Node.Mode.EXCLUSIVE : Node.Mode.NORMAL;
+        final EC2FleetNode node = new EC2FleetNode(instanceId, "Fleet slave for " + instanceId,
+                effectiveFsRoot, effectiveNumExecutors, nodeMode, labelString, new ArrayList<NodeProperty<?>>(),
+                this, computerLauncher);
+
+        // Initialize our retention strategy
+        node.setRetentionStrategy(new IdleRetentionStrategy());
+
+        final Jenkins jenkins = Jenkins.getInstance();
+        // jenkins automatically remove old node with same name if any
+        jenkins.addNode(node);
+
+        final SettableFuture<Node> future;
+        if (state.plannedNodes.isEmpty()) {
+            future = SettableFuture.create();
+        } else {
+            final Iterator<NodeProvisioner.PlannedNode> iterator = state.plannedNodes.iterator();
+            final NodeProvisioner.PlannedNode plannedNode = iterator.next();
+            // we remove for list as it could be multiple nodes added in one update
+            iterator.remove();
+            state.plannedNodesToRemove.add(plannedNode);
+            future = ((SettableFuture<Node>) plannedNode.future);
+        }
+
+        // use getters for timeout and interval as they provide default value
+        // when user just install new version and did't recreate fleet
+        EC2FleetOnlineChecker.start(node, future,
+                TimeUnit.SECONDS.toMillis(getInitOnlineTimeoutSec()),
+                TimeUnit.SECONDS.toMillis(getInitOnlineCheckIntervalSec()));
+    }
+
+    private String getLogPrefix() {
+        return getDisplayName() + " ";
+    }
+
+    private void info(final String msg, final Object... args) {
+        LOGGER.info(getLogPrefix() + String.format(msg, args));
+    }
+
+    private void fine(final String msg, final Object... args) {
+        LOGGER.fine(getLogPrefix() + String.format(msg, args));
+    }
+
+    private void warning(final String msg, final Object... args) {
+        LOGGER.warning(getLogPrefix() + String.format(msg, args));
+    }
+
+    private void warning(final Throwable t, final String msg, final Object... args) {
+        LOGGER.log(Level.WARNING, getLogPrefix() + String.format(msg, args), t);
+    }
+
+    // todo to collection utils
+    private static <T> Set<T> missed(Set<T> what, Set<T> where) {
+        final Set<T> m = new HashSet<>();
+        for (T item : what) {
+            if (!where.contains(item)) m.add(item);
+        }
+        return m;
+    }
+
+    public void updateStacks() {
+//        if (NEW_EC2_KEY_PAIR_VALUE.equals(ec2KeyPairName)) {
+//            // need to create key first
+//            final AmazonEC2 amazonEC2 = Registry.getEc2Api().connect(awsCredentialsId, region, endpoint);
+//            final CreateKeyPairResult result = amazonEC2.createKeyPair(new CreateKeyPairRequest().withKeyName(
+//                    "ec2-fleet-plugin-" + new SimpleDateFormat("yyyy-MM-dd-hh-mm-ss").format(new Date())));
+//            Jenkins.getActiveInstance().cre
+//            ec2KeyPairName = result.getKeyPair().getKeyName();
+//        }
+
+        final Jenkins jenkins = Jenkins.getActiveInstance();
+        final CloudFormationApi cloudFormationApi = Registry.getCloudFormationApi();
+        final AmazonCloudFormation client = cloudFormationApi.connect(awsCredentialsId, region, endpoint);
+        final Map<String, CloudFormationApi.StackInfo> allStacks = cloudFormationApi.describe(client, name);
+
+        // labels
+        final Set<String> labels = new HashSet<>();
+        for (final Item item : Jenkins.getActiveInstance().getAllItems()) {
+            if (!(item instanceof AbstractProject)) continue;
+            final AbstractProject abstractProject = (AbstractProject) item;
+            // assinged label could be null
+            final String labelString = StringUtils.defaultString(abstractProject.getAssignedLabelString());
+
+            if (labelString.startsWith(name)) {
+                labels.add(labelString);
+            }
+        }
+
+        Set<String> labelsWithoutStacks = missed(labels, allStacks.keySet());
+        Set<String> stacksWithoutLabels = missed(allStacks.keySet(), labels);
+
+        Set<String> stacksWithLabels = new HashSet<>(allStacks.keySet());
+        stacksWithLabels.removeAll(stacksWithoutLabels);
+
+        final Set<String> runningStacksWithLabels = new HashSet<>();
+        for (Map.Entry<String, CloudFormationApi.StackInfo> stack : allStacks.entrySet()) {
+            if (labels.contains(stack.getKey()) && stack.getValue().stackStatus == StackStatus.CREATE_COMPLETE) {
+                runningStacksWithLabels.add(stack.getKey());
+            }
+        }
+        LOGGER.info("running stacks " + runningStacksWithLabels);
+
+        // sync with stacks
+
+        // new stacks
+        for (final String label : labelsWithoutStacks) {
+            LOGGER.info("creating stack for label " + label);
+            cloudFormationApi.create(client, name, ec2KeyPairName, label);
+        }
+
+        // delete unused stacks
+        for (final String label : stacksWithoutLabels) {
+            final CloudFormationApi.StackInfo stack = allStacks.get(label);
+            if (stack.stackStatus == StackStatus.CREATE_COMPLETE) {
+                LOGGER.info("deleting unused stack " + stack.stackId + " for label " + label);
+                cloudFormationApi.delete(client, stack.stackId);
+
+                // delete all nodes which belongs to this stack
+                final List<String> instanceIdsToRemove = new ArrayList<>();
+                Queue.withLock(new Runnable() {
+                    @Override
+                    public void run() {
+                        for (final Node node : jenkins.getNodes()) {
+                            if (label.equals(node.getLabelString())) {
+                                final String instanceId = node.getNodeName();
+                                instanceIdsToRemove.add(instanceId);
+                                try {
+                                    jenkins.removeNode(node);
+                                } catch (IOException e) {
+                                    warning("unable delete node %s from Jenkins, skip, " +
+                                            "actual instance will be terminated by stack", instanceId);
+                                }
+                            }
+                        }
+                    }
+                });
+                info("Delete nodes from deleted stack from Jenkins %s", instanceIdsToRemove);
+            } else {
+                LOGGER.info("unused stack " + stack.stackId + " for label " + label
+                        + " is status " + stack.stackStatus + ", skip to delete");
+            }
+        }
+
+        synchronized (this) {
+            // sync states
+
+            // add states with new stack
+            for (final String label : runningStacksWithLabels) {
+                if (!states.containsKey(label)) {
+                    final CloudFormationApi.StackInfo stack = allStacks.get(label);
+                    states.put(label, new State(stack.fleetId));
+                }
+            }
+
+            // remove states without stack
+            Iterator<Map.Entry<String, State>> iterator = states.entrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<String, State> state = iterator.next();
+                if (!runningStacksWithLabels.contains(state.getKey())) {
+                    iterator.remove();
+                }
+            }
+        }
+    }
+
+    @Extension
+    @SuppressWarnings("unused")
+    public static class DescriptorImpl extends Descriptor<Cloud> {
+
+        public String accessId;
+        public String secretKey;
+        public String region;
+        public String privateKey;
+
+        public DescriptorImpl() {
+            super();
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Amazon EC2 Fleet label based";
+        }
+
+        public List getComputerConnectorDescriptors() {
+            return Jenkins.getInstance().getDescriptorList(ComputerConnector.class);
+        }
+
+        public ListBoxModel doFillAwsCredentialsIdItems() {
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getInstance());
+        }
+
+        public ListBoxModel doFillRegionItems(@QueryParameter final String awsCredentialsId) {
+            // to keep user consistent order tree set
+            final Set<String> regionNames = new TreeSet<>();
+
+            try {
+                final AmazonEC2 client = Registry.getEc2Api().connect(awsCredentialsId, null, null);
+                final DescribeRegionsResult regions = client.describeRegions();
+                for (final Region region : regions.getRegions()) {
+                    regionNames.add(region.getRegionName());
+                }
+            } catch (final Exception ex) {
+                // ignore exception it could be case that credentials are not belong to default region
+                // which we are using to describe regions
+            }
+
+            for (final com.amazonaws.regions.Region region : RegionUtils.getRegions()) {
+                regionNames.add(region.getName());
+            }
+
+            final ListBoxModel model = new ListBoxModel();
+            for (final String regionName : regionNames) {
+                model.add(new ListBoxModel.Option(regionName, regionName));
+            }
+            return model;
+        }
+
+        public ListBoxModel doFillEc2KeyPairNameItems(
+                @QueryParameter final String awsCredentialsId,
+                @QueryParameter final String region,
+                @QueryParameter final String endpoint) {
+            final ListBoxModel model = new ListBoxModel();
+//            model.add(NEW_EC2_KEY_PAIR_VALUE);
+
+            try {
+                final AmazonEC2 amazonEC2 = new EC2Api().connect(awsCredentialsId, region, endpoint);
+                final List<KeyPairInfo> keyPairs = amazonEC2.describeKeyPairs().getKeyPairs();
+                for (final KeyPairInfo keyPair : keyPairs) {
+                    model.add(new ListBoxModel.Option(keyPair.getKeyName(), keyPair.getKeyName()));
+                }
+            } catch (Exception e) {
+                LOGGER.log(Level.WARNING, String.format(
+                        "Cannot describe key pairs credentials %s region %s endpoint %s",
+                        awsCredentialsId, region, endpoint), e);
+            }
+            return model;
+        }
+
+        public FormValidation doTestConnection(
+                @QueryParameter final String awsCredentialsId,
+                @QueryParameter final String region,
+                @QueryParameter final String endpoint,
+                @QueryParameter final String fleet) {
+            try {
+                // read state to check if we have access
+                EC2Fleets.get(fleet).getState(awsCredentialsId, region, endpoint, fleet);
+            } catch (final Exception ex) {
+                return FormValidation.error(ex.getMessage());
+            }
+            return FormValidation.ok("Success");
+        }
+
+        @Override
+        public boolean configure(final StaplerRequest req, final JSONObject formData) throws FormException {
+            req.bindJSON(this, formData);
+            save();
+            return super.configure(req, formData);
+        }
+
+        public String getAccessId() {
+            return accessId;
+        }
+
+        public String getSecretKey() {
+            return secretKey;
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+    }
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParameters.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParameters.java
@@ -1,0 +1,43 @@
+package com.amazon.jenkins.ec2fleet;
+
+import javax.annotation.concurrent.ThreadSafe;
+import java.util.HashMap;
+import java.util.Map;
+
+@ThreadSafe
+public class EC2FleetLabelParameters {
+
+    private final Map<String, String> parameters;
+
+    public EC2FleetLabelParameters(final String label) {
+        parameters = parse(label);
+    }
+
+    public String get(String name) {
+        return parameters.get(name);
+    }
+
+    public String getOrDefault(String name, String defaultValue) {
+        final String value = parameters.get(name);
+        return value == null ? defaultValue : value;
+    }
+
+    public int getIntOrDefault(String name, int defaultValue) {
+        final String value = parameters.get(name);
+        return value == null ? defaultValue : Integer.parseInt(value);
+    }
+
+    private static Map<String, String> parse(final String label) {
+        final Map<String, String> p = new HashMap<>();
+        if (label == null) return p;
+
+        final String[] parameters = label.substring(label.indexOf('_') + 1).split(",");
+        for (final String parameter : parameters) {
+            String[] keyValue = parameter.split("=");
+            if (keyValue.length == 2) {
+                p.put(keyValue[0], keyValue[1]);
+            }
+        }
+        return p;
+    }
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParameters.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParameters.java
@@ -13,17 +13,18 @@ public class EC2FleetLabelParameters {
         parameters = parse(label);
     }
 
-    public String get(String name) {
-        return parameters.get(name);
+    public String get(final String name) {
+        // todo add fail on null name
+        return parameters.get(name.toLowerCase());
     }
 
     public String getOrDefault(String name, String defaultValue) {
-        final String value = parameters.get(name);
+        final String value = get(name);
         return value == null ? defaultValue : value;
     }
 
     public int getIntOrDefault(String name, int defaultValue) {
-        final String value = parameters.get(name);
+        final String value = get(name);
         return value == null ? defaultValue : Integer.parseInt(value);
     }
 
@@ -35,7 +36,7 @@ public class EC2FleetLabelParameters {
         for (final String parameter : parameters) {
             String[] keyValue = parameter.split("=");
             if (keyValue.length == 2) {
-                p.put(keyValue[0], keyValue[1]);
+                p.put(keyValue[0].toLowerCase(), keyValue[1]);
             }
         }
         return p;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelUpdater.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelUpdater.java
@@ -1,0 +1,43 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.Extension;
+import hudson.model.PeriodicWork;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+// todo make configurable
+@Extension
+@SuppressWarnings("unused")
+public class EC2FleetLabelUpdater extends PeriodicWork {
+
+    private static final Logger LOGGER = Logger.getLogger(EC2FleetLabelUpdater.class.getName());
+
+    @Override
+    public long getRecurrencePeriod() {
+        return TimeUnit.SECONDS.toMillis(30);
+    }
+
+    @Override
+    protected void doRun() {
+        for (Cloud cloud : Jenkins.getActiveInstance().clouds) {
+            if (!(cloud instanceof EC2FleetLabelCloud)) continue;
+            final EC2FleetLabelCloud ec2FleetLabelCloud = (EC2FleetLabelCloud) cloud;
+            try {
+                ec2FleetLabelCloud.updateStacks();
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, "Cloud stacks update error", t);
+            }
+
+            try {
+                ec2FleetLabelCloud.update();
+            } catch (Throwable t) {
+                LOGGER.log(Level.SEVERE, "Cloud update error", t);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNode.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNode.java
@@ -16,10 +16,10 @@ import java.util.List;
 
 public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudAware {
 
-    private volatile EC2FleetCloud cloud;
+    private volatile AbstractEC2FleetCloud cloud;
 
     public EC2FleetNode(final String name, final String nodeDescription, final String remoteFS, final int numExecutors, final Mode mode, final String label,
-                        final List<? extends NodeProperty<?>> nodeProperties, final EC2FleetCloud cloud, ComputerLauncher launcher) throws IOException, Descriptor.FormException {
+                        final List<? extends NodeProperty<?>> nodeProperties, final AbstractEC2FleetCloud cloud, ComputerLauncher launcher) throws IOException, Descriptor.FormException {
         //noinspection deprecation
         super(name, nodeDescription, remoteFS, numExecutors, mode, label,
                 launcher, RetentionStrategy.NOOP, nodeProperties);
@@ -43,7 +43,7 @@ public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudA
     }
 
     @Override
-    public EC2FleetCloud getCloud() {
+    public AbstractEC2FleetCloud getCloud() {
         return cloud;
     }
 
@@ -51,7 +51,7 @@ public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudA
      * {@inheritDoc}
      */
     @Override
-    public void setCloud(@Nonnull EC2FleetCloud cloud) {
+    public void setCloud(@Nonnull AbstractEC2FleetCloud cloud) {
         this.cloud = cloud;
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -15,9 +15,9 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
 
     private final String name;
 
-    private volatile EC2FleetCloud cloud;
+    private volatile AbstractEC2FleetCloud cloud;
 
-    public EC2FleetNodeComputer(final Slave slave, @Nonnull final String name, @Nonnull final EC2FleetCloud cloud) {
+    public EC2FleetNodeComputer(final Slave slave, @Nonnull final String name, @Nonnull final AbstractEC2FleetCloud cloud) {
         super(slave);
         this.name = name;
         this.cloud = cloud;
@@ -45,12 +45,12 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
      * {@inheritDoc}
      */
     @Override
-    public void setCloud(@Nonnull final EC2FleetCloud cloud) {
+    public void setCloud(@Nonnull final AbstractEC2FleetCloud cloud) {
         this.cloud = cloud;
     }
 
     @Override
-    public EC2FleetCloud getCloud() {
+    public AbstractEC2FleetCloud getCloud() {
         return cloud;
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/IdleRetentionStrategy.java
@@ -27,7 +27,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer> {
     @Override
     public long check(final SlaveComputer computer) {
         final EC2FleetNodeComputer fc = (EC2FleetNodeComputer) computer;
-        final EC2FleetCloud cloud = fc.getCloud();
+        final AbstractEC2FleetCloud cloud = fc.getCloud();
 
         LOGGER.log(Level.INFO, "Check if node idle " + computer.getName());
 
@@ -78,7 +78,7 @@ public class IdleRetentionStrategy extends RetentionStrategy<SlaveComputer> {
         c.connect(false);
     }
 
-    private boolean isIdleForTooLong(final EC2FleetCloud cloud, final Computer computer) {
+    private boolean isIdleForTooLong(final AbstractEC2FleetCloud cloud, final Computer computer) {
         final int idleMinutes = cloud.getIdleMinutes();
         if (idleMinutes <= 0) return false;
         final long idleTime = System.currentTimeMillis() - computer.getIdleStartMilliseconds();

--- a/src/main/java/com/amazon/jenkins/ec2fleet/JenkinsUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/JenkinsUtils.java
@@ -1,0 +1,21 @@
+package com.amazon.jenkins.ec2fleet;
+
+import hudson.model.Node;
+import jenkins.model.Jenkins;
+
+public class JenkinsUtils {
+
+    public static void removeNode(final String instanceId) {
+        final Jenkins jenkins = Jenkins.getActiveInstance();
+        // If this node is dying, remove it from Jenkins
+        final Node n = jenkins.getNode(instanceId);
+        if (n != null) {
+            try {
+                jenkins.removeNode(n);
+            } catch (final Exception ex) {
+                throw new IllegalStateException(String.format("Error removing node %s", instanceId), ex);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/Registry.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/Registry.java
@@ -11,6 +11,7 @@ package com.amazon.jenkins.ec2fleet;
 public class Registry {
 
     private static EC2Api ec2Api = new EC2Api();
+    private static CloudFormationApi cloudFormationApi = new CloudFormationApi();
 
     public static void setEc2Api(EC2Api ec2Api) {
         Registry.ec2Api = ec2Api;
@@ -18,6 +19,14 @@ public class Registry {
 
     public static EC2Api getEc2Api() {
         return ec2Api;
+    }
+
+    public static CloudFormationApi getCloudFormationApi() {
+        return cloudFormationApi;
+    }
+
+    public static void setCloudFormationApi(CloudFormationApi cloudFormationApi) {
+        Registry.cloudFormationApi = cloudFormationApi;
     }
 
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -20,8 +20,10 @@ import org.springframework.util.ObjectUtils;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 @ThreadSafe
@@ -90,6 +92,11 @@ public class AutoScalingGroupFleet implements EC2Fleet {
                 FleetStateStats.State.active(StringUtils.defaultIfEmpty(group.getStatus(), "active")),
                 // auto scaling groups don't support weight, may be in future
                 instanceIds, Collections.<String, Double>emptyMap());
+    }
+
+    @Override
+    public Map<String, FleetStateStats> getStateBatch(String awsCredentialsId, String regionName, String endpoint, Collection<String> ids) {
+        throw new UnsupportedOperationException();
     }
 
     private AmazonAutoScalingClient createClient(

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleet.java
@@ -3,6 +3,9 @@ package com.amazon.jenkins.ec2fleet.fleet;
 import com.amazon.jenkins.ec2fleet.FleetStateStats;
 import hudson.util.ListBoxModel;
 
+import java.util.Collection;
+import java.util.Map;
+
 /**
  * Hide details of access to EC2 Fleet depending on implementation like EC2 Fleet based on EC2 Spot Fleet
  * or Auto Scaling Group.
@@ -23,5 +26,9 @@ public interface EC2Fleet {
     FleetStateStats getState(
             final String awsCredentialsId, final String regionName, final String endpoint,
             final String id);
+
+    Map<String, FleetStateStats> getStateBatch(
+            final String awsCredentialsId, final String regionName, final String endpoint,
+            final Collection<String> ids);
 
 }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
@@ -1,0 +1,100 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
+         xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+         xmlns:c="/lib/credentials">
+
+    <f:entry title="${%Name}" field="name">
+        <f:textbox default="FleetCloudLabel"/>
+    </f:entry>
+
+    <!-- we use this hidden field to be able detect previous name of cloud
+     see javadoc for EC2FleetCloudAware -->
+    <f:invisibleEntry>
+        <f:textbox field="oldId" />
+    </f:invisibleEntry>
+
+    <f:entry title="${%AWS Credentials}" field="awsCredentialsId">
+      <c:select/>
+    </f:entry>
+
+    <f:description>Select <a href="https://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#cnnorth_region">China region</a> for China credentials.</f:description>
+    <f:entry title="${%Region}" field="region">
+      <f:select/>
+    </f:entry>
+
+    <f:description>Endpoint like https://ec2.us-east-2.amazonaws.com</f:description>
+    <f:entry title="${%Endpoint}" field="endpoint">
+      <f:textbox default=""/>
+    </f:entry>
+
+<!--    <f:description>EC2 SSH Key Name</f:description>-->
+<!--    <f:entry title="${%EC2 Key Name}" field="ec2KeyPairName">-->
+<!--        <f:select/>-->
+<!--    </f:entry>-->
+
+    <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="awsCredentialsId,region,fleet" />
+
+    <f:entry title="${%Launcher}" field="laucnher">
+      <f:dropdownDescriptorSelector field="computerConnector" descriptors="${descriptor.getComputerConnectorDescriptors()}"/>
+    </f:entry>
+
+    <f:description>Connect using private IP</f:description>
+    <f:entry title="${%Connect Private}" field="privateIpUsed">
+      <f:checkbox />
+    </f:entry>
+
+    <f:description>Always reconnect to offline nodes</f:description>
+    <f:entry title="${%Always Reconnect}" field="alwaysReconnect">
+      <f:checkbox />
+    </f:entry>
+
+    <f:description>Only build jobs with label expressions matching this node
+    </f:description>
+    <f:entry title="${%Restrict usage}" field="restrictUsage">
+      <f:checkbox />
+    </f:entry>
+
+    <f:description>Default is /tmp/jenkins-&lt;random ID&gt;</f:description>
+    <f:entry title="${%Jenkins Filesystem Root}" field="fsRoot">
+      <f:textbox />
+    </f:entry>
+
+    <f:description>Number of executors per instance</f:description>
+    <f:entry title="${%Number of Executors}" field="numExecutors">
+      <f:textbox clazz="required positive-number" default="1" />
+    </f:entry>
+
+    <f:entry title="${%Max Idle Minutes Before Scaledown}" field="idleMinutes">
+      <f:number clazz="required number" min="0" default="0" />
+    </f:entry>
+
+    <f:entry title="${%Minimum Cluster Size}" field="minSize">
+      <f:number clazz="required number" min="0" default="1" />
+    </f:entry>
+
+    <f:entry title="${%Maximum Cluster Size}" field="maxSize">
+      <f:number clazz="required positive-number" default="1" />
+    </f:entry>
+
+    <f:description>Disable auto resubmit build if failed because of EC2 instance termination like Spot</f:description>
+    <f:entry title="${%Disable build resubmit}" field="disableTaskResubmit">
+      <f:checkbox />
+    </f:entry>
+
+    <f:description>Maximum time to wait for EC2 instance startup</f:description>
+    <f:entry title="${%Maximum Init Connection Timeout in sec}" field="initOnlineTimeoutSec">
+      <f:number clazz="required positive-number" default="180" />
+    </f:entry>
+
+    <f:description>Interval for updating EC2 cloud status</f:description>
+    <f:entry title="${%Cloud Status Interval in sec}" field="cloudStatusIntervalSec">
+      <f:number clazz="required positive-number" default="10" />
+    </f:entry>
+
+    <f:description>Enable faster provision when queue is growing</f:description>
+    <f:entry title="${%No Delay Provision Strategy}" field="noDelayProvision">
+      <f:checkbox />
+    </f:entry>
+
+</j:jelly>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/auto-scaling-group.yml
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/auto-scaling-group.yml
@@ -1,0 +1,48 @@
+Parameters:
+  InstanceType:
+    Type: String
+  ImageId:
+    Type: String
+  SpotPrice:
+    Type: String
+  MaxSize:
+    Type: String
+  MinSize:
+    Type: String
+  KeyName:
+    Type: String
+
+Outputs:
+  FleetId:
+    Value:
+      Ref: ASG
+
+Resources:
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html#aws-properties-as-launchconfig-properties
+  ASGLaunchConfig:
+    Type: AWS::AutoScaling::LaunchConfiguration
+    Properties:
+      ImageId:
+        Ref: ImageId
+#      UserData:
+#        Fn::Base64:
+#          Ref: "WebServerPort"
+      InstanceType:
+        Ref: InstanceType
+      SpotPrice:
+        Ref: SpotPrice
+      KeyName:
+        Ref: KeyName
+
+  ASG:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AvailabilityZones:
+        Fn::GetAZs:
+          Ref: AWS::Region
+      LaunchConfigurationName:
+        Ref: ASGLaunchConfig
+      MinSize:
+        Ref: MinSize
+      MaxSize:
+        Ref: MaxSize

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/ec2-spot-fleet.yml
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/ec2-spot-fleet.yml
@@ -1,0 +1,50 @@
+Parameters:
+  InstanceType:
+    Type: String
+  ImageId:
+    Type: String
+  SpotPrice:
+    Type: String
+  MaxSize:
+    Type: String
+  MinSize:
+    Type: String
+  KeyName:
+    Type: String
+
+Outputs:
+  FleetId:
+    Value:
+      Ref: SpotFleet
+
+Resources:
+  SpotFleetRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - spotfleet.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetTaggingRole
+
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-spotfleet-spotfleetrequestconfigdata-launchspecifications.html
+  SpotFleet:
+    Type: AWS::EC2::SpotFleet
+    Properties:
+      SpotFleetRequestConfigData:
+        IamFleetRole: !GetAtt [SpotFleetRole, Arn]
+        TargetCapacity:
+          Ref: MinSize
+        LaunchSpecifications:
+          - InstanceType:
+              Ref: InstanceType
+            ImageId:
+              Ref: ImageId
+            KeyName:
+              Ref: KeyName

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloudIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloudIntegrationTest.java
@@ -1,0 +1,97 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazonaws.services.cloudformation.AmazonCloudFormation;
+import com.amazonaws.services.cloudformation.model.DeleteStackRequest;
+import com.amazonaws.services.ec2.model.InstanceStateName;
+import hudson.model.FreeStyleProject;
+import hudson.model.labels.LabelAtom;
+import hudson.model.queue.QueueTaskFuture;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+
+public class EC2FleetLabelCloudIntegrationTest extends IntegrationTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        setJenkinsTestTimoutTo720();
+    }
+
+    @Test
+    public void should_create_stack_and_provision_node_for_task_execution() throws Exception {
+        mockEc2FleetApiToEc2SpotFleet(InstanceStateName.Running);
+        mockCloudFormationApi();
+
+        EC2FleetLabelCloud cloud = new EC2FleetLabelCloud("FleetLabel", null, "credId", "region",
+                null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
+                0, 0, 0, 1, false,
+                false, 0, 0, false,
+                2, false, "test1");
+        j.jenkins.clouds.add(cloud);
+
+        // set max size to > 0 otherwise nothing to provision
+        final String labelString = "FleetLabel_maxSize=1";
+        final List<QueueTaskFuture> rs = enqueTask(1, labelString);
+
+        Assert.assertEquals(0, j.jenkins.getNodes().size());
+
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                triggerSuggestReviewNow(labelString);
+                assertTasksDone(rs);
+            }
+        }, TimeUnit.MINUTES.toMillis(4));
+
+        cancelTasks(rs);
+    }
+
+    @Test
+    public void should_delete_resources_if_label_unused() throws Exception {
+        mockEc2FleetApiToEc2SpotFleet(InstanceStateName.Running);
+        final AmazonCloudFormation amazonCloudFormation = mockCloudFormationApi();
+
+        EC2FleetLabelCloud cloud = new EC2FleetLabelCloud("FleetLabel", null, "credId", "region",
+                null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
+                0, 0, 0, 1, false,
+                false, 0, 0, false,
+                2, false, "test1");
+        j.jenkins.clouds.add(cloud);
+
+        // set max size to > 0 otherwise nothing to provision
+        final String labelString = "FleetLabel_maxSize=1";
+        final List<QueueTaskFuture> rs = enqueTask(1, labelString);
+
+        // wait until tasks will be completed
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                triggerSuggestReviewNow(labelString);
+                assertTasksDone(rs);
+            }
+        }, TimeUnit.MINUTES.toMillis(4));
+
+        // remove label from task (unused)
+        FreeStyleProject freeStyleProject = (FreeStyleProject) j.jenkins.getAllItems().get(0);
+        freeStyleProject.setAssignedLabel(new LabelAtom("nothing"));
+
+        // wait until stack will be deleted and nodes will be removed as well
+        tryUntil(new Runnable() {
+            @Override
+            public void run() {
+                Assert.assertEquals(Collections.emptyList(), j.jenkins.getNodes());
+                Mockito.verify(amazonCloudFormation).deleteStack(any(DeleteStackRequest.class));
+            }
+        }, TimeUnit.MINUTES.toMillis(2));
+
+        cancelTasks(rs);
+    }
+
+}

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParametersTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParametersTest.java
@@ -26,6 +26,17 @@ public class EC2FleetLabelParametersTest {
     }
 
     @Test
+    public void get_caseInsensitive() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("aBc=1");
+        Assert.assertEquals("1", parameters.get("aBc"));
+        Assert.assertEquals("1", parameters.get("ABC"));
+        Assert.assertEquals("1", parameters.get("abc"));
+        Assert.assertEquals("1", parameters.get("AbC"));
+        Assert.assertEquals("1", parameters.getOrDefault("AbC", "?"));
+        Assert.assertEquals(1, parameters.getIntOrDefault("AbC", -1));
+    }
+
+    @Test
     public void parse_withFleetNamePrefixSkipItAndProvideParameters() {
         final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("AA_a=1,b=2");
         Assert.assertEquals("1", parameters.get("a"));

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParametersTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelParametersTest.java
@@ -1,0 +1,64 @@
+package com.amazon.jenkins.ec2fleet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EC2FleetLabelParametersTest {
+
+    @Test
+    public void parse_emptyForEmptyString() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("");
+        Assert.assertNull(parameters.get("aa"));
+    }
+
+    @Test
+    public void parse_emptyForNullString() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters(null);
+        Assert.assertNull(parameters.get("aa"));
+    }
+
+    @Test
+    public void parse_forString() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("a=1,b=2");
+        Assert.assertEquals("1", parameters.get("a"));
+        Assert.assertEquals("2", parameters.get("b"));
+        Assert.assertNull(parameters.get("c"));
+    }
+
+    @Test
+    public void parse_withFleetNamePrefixSkipItAndProvideParameters() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("AA_a=1,b=2");
+        Assert.assertEquals("1", parameters.get("a"));
+        Assert.assertEquals("2", parameters.get("b"));
+        Assert.assertNull(parameters.get("c"));
+    }
+
+    @Test
+    public void parse_withEmptyFleetNamePrefixSkipItAndProvideParameters() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("_a=1,b=2");
+        Assert.assertEquals("1", parameters.get("a"));
+        Assert.assertEquals("2", parameters.get("b"));
+        Assert.assertNull(parameters.get("c"));
+    }
+
+    @Test
+    public void parse_withEmptyFleetNamePrefixAndEmptyParametersReturnsEmpty() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("_");
+        Assert.assertNull(parameters.get("c"));
+    }
+
+    @Test
+    public void parse_skipParameterWithoutValue() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("withoutValue,b=2");
+        Assert.assertEquals("2", parameters.get("b"));
+        Assert.assertNull(parameters.get("withoutValue"));
+    }
+
+    @Test
+    public void parse_skipParameterWithEmptyValue() {
+        final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters("withoutValue=,b=2");
+        Assert.assertEquals("2", parameters.get("b"));
+        Assert.assertNull(parameters.get("withoutValue"));
+    }
+
+}


### PR DESCRIPTION
This feature auto manages EC2 Spot Fleet or ASG based Fleets for Jenkins based on 
label attached to Jenkins Jobs.

With this feature user of EC2 Fleet Plugin doesn't need to have pre-created AWS resources 
to start configuration and run Jobs. Plugin required just AWS Credentials 
with permissions to be able create resources.

# How It Works

- Plugin detects all labeled Jobs where Label starts from Name configured in plugin configuration ```Cloud Name```
- Plugin parses Label to get Fleet configuration
- Plugin creates dedicated fleet for each unique Label
  - Plugin uses [CloudFormation Stacks](https://aws.amazon.com/cloudformation/) to provision Fleet and all required resources
- When Label is not used by any Job Plugin deletes Stack and release resources 