### PR TITLE
Add checking AWS Permission using Test Connection button

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/AwsPermissionChecker.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/AwsPermissionChecker.java
@@ -86,7 +86,6 @@ public class AwsPermissionChecker {
         if(!hasDescribeAutoScalingGroupsPermission(asgClient)) {
             missingAsgPermissions.add(FleetAPI.DescribeAutoScalingGroups.name());
         }
-
         return missingAsgPermissions;
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/AwsPermissionChecker.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/AwsPermissionChecker.java
@@ -1,0 +1,126 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.amazon.jenkins.ec2fleet.fleet.AutoScalingGroupFleet;
+import com.amazon.jenkins.ec2fleet.fleet.EC2Fleets;
+import com.amazonaws.services.autoscaling.AmazonAutoScalingClient;
+import com.amazonaws.services.autoscaling.model.AmazonAutoScalingException;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.model.CreateTagsRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeSpotFleetRequestsRequest;
+import com.amazonaws.services.ec2.model.DryRunResult;
+import com.amazonaws.services.ec2.model.ModifySpotFleetRequestRequest;
+import com.amazonaws.services.ec2.model.Tag;
+import org.apache.commons.lang.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AwsPermissionChecker {
+    private static final int UNAUTHORIZED_STATUS_CODE = 403;
+
+    private String awsCrendentialsId;
+    private String regionName;
+    private String endpoint;
+
+    public AwsPermissionChecker(final String awsCrendentialsId, final String regionName, final String endpoint) {
+        this.awsCrendentialsId = awsCrendentialsId;
+        this.regionName = regionName;
+        this.endpoint = endpoint;
+    }
+
+    public enum FleetAPI {
+        DescribeInstances,
+        DescribeSpotFleetInstances,
+        CreateTags,
+        ModifySpotFleetRequest,
+        DescribeSpotFleetRequests,
+        DescribeAutoScalingGroups,
+        TerminateInstances, // TODO: Dry-run throws invalid instanceID first then AuthZ error. We need to find a better way to test
+        UpdateAutoScalingGroup; // TODO: There is no dry-run for AutoScalingClient
+    };
+
+    public List<String> getMissingPermissions(final String fleet) {
+        final AmazonEC2 ec2Client = Registry.getEc2Api().connect(awsCrendentialsId, regionName, endpoint);
+        final List<String> missingPermissions = new ArrayList<>(getMissingCommonPermissions(ec2Client));
+        if(StringUtils.isBlank(fleet)) { // Since we don't know the fleet type, show permissions for both
+            missingPermissions.addAll(getMissingPermissionsForEC2Fleet(ec2Client, fleet));
+            missingPermissions.addAll(getMissingPermissionsForASG());
+        } else if(EC2Fleets.isEC2Fleet(fleet)) {
+            missingPermissions.addAll(getMissingPermissionsForEC2Fleet(ec2Client, fleet));
+        } else {
+            missingPermissions.addAll(getMissingPermissionsForASG());
+        }
+        return missingPermissions;
+    }
+
+    private List<String> getMissingPermissionsForEC2Fleet(final AmazonEC2 ec2Client, final String fleet) {
+        final List<String> missingEC2FleetPermissions = new ArrayList<>();
+        if(!hasDescribeSpotFleetRequestsPermission(ec2Client)) {
+            missingEC2FleetPermissions.add(FleetAPI.DescribeSpotFleetRequests.name());
+        }
+        if(!hasDescribeSpotFleetInstancesPermission(ec2Client)) {
+            missingEC2FleetPermissions.add(FleetAPI.DescribeSpotFleetInstances.name());
+        }
+        if(!hasModifySpotFleetRequestPermission(ec2Client, fleet)) {
+            missingEC2FleetPermissions.add(FleetAPI.ModifySpotFleetRequest.name());
+        }
+        return missingEC2FleetPermissions;
+    }
+
+    private List<String> getMissingCommonPermissions(final AmazonEC2 ec2Client) {
+        final List<String> missingCommonPermissions = new ArrayList<>();
+        if(!hasDescribeInstancePermission(ec2Client)) {
+            missingCommonPermissions.add(FleetAPI.DescribeInstances.name());
+        }
+        if(!hasCreateTagsPermissions(ec2Client)) {
+            missingCommonPermissions.add(FleetAPI.CreateTags.name());
+        }
+        return missingCommonPermissions;
+    }
+
+    private List<String> getMissingPermissionsForASG() {
+        final AmazonAutoScalingClient asgClient = new AutoScalingGroupFleet().createClient(awsCrendentialsId, regionName, endpoint);
+        List<String> missingAsgPermissions = new ArrayList<>();
+        if(!hasDescribeAutoScalingGroupsPermission(asgClient)) {
+            missingAsgPermissions.add(FleetAPI.DescribeAutoScalingGroups.name());
+        }
+
+        return missingAsgPermissions;
+    }
+
+    private boolean hasModifySpotFleetRequestPermission(final AmazonEC2 ec2Client, final String fleet) {
+        final DryRunResult<ModifySpotFleetRequestRequest> dryRunResult = ec2Client.dryRun(new ModifySpotFleetRequestRequest().withSpotFleetRequestId(fleet));
+        return dryRunResult.getDryRunResponse().getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+    }
+
+    private boolean hasDescribeSpotFleetInstancesPermission(final AmazonEC2 ec2Client) {
+        final DryRunResult<DescribeSpotFleetInstancesRequest> dryRunResult = ec2Client.dryRun(new DescribeSpotFleetInstancesRequest());
+        return dryRunResult.getDryRunResponse().getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+    }
+
+    private boolean hasDescribeSpotFleetRequestsPermission(final AmazonEC2 ec2Client) {
+        final DryRunResult<DescribeSpotFleetRequestsRequest> dryRunResult = ec2Client.dryRun(new DescribeSpotFleetRequestsRequest());
+        return dryRunResult.getDryRunResponse().getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+    }
+
+    private boolean hasDescribeAutoScalingGroupsPermission(final AmazonAutoScalingClient asgClient) {
+        try {
+            asgClient.describeAutoScalingGroups();
+        } catch (final AmazonAutoScalingException ex) {
+            return ex.getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+        }
+        return Boolean.TRUE;
+    }
+
+    private boolean hasCreateTagsPermissions(final AmazonEC2 ec2Client) {
+        final DryRunResult<CreateTagsRequest> dryRunResult = ec2Client.dryRun(new CreateTagsRequest().withTags(new Tag().withKey("instanceId").withValue("i-1234")));
+        return dryRunResult.getDryRunResponse().getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+    }
+
+    private boolean hasDescribeInstancePermission(final AmazonEC2 ec2Client) {
+        final DryRunResult<DescribeInstancesRequest> dryRunResult = ec2Client.dryRun(new DescribeInstancesRequest());
+        return dryRunResult.getDryRunResponse().getStatusCode() != UNAUTHORIZED_STATUS_CODE;
+    }
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -838,13 +838,20 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 @QueryParameter final String region,
                 @QueryParameter final String endpoint,
                 @QueryParameter final String fleet) {
-            try {
-                // read state to check if we have access
-                EC2Fleets.get(fleet).getState(awsCredentialsId, region, endpoint, fleet);
-            } catch (final Exception ex) {
-                return FormValidation.error(ex.getMessage());
+
+            // Check if any missing AWS Permissions
+            final AwsPermissionChecker awsPermissionChecker = new AwsPermissionChecker(awsCredentialsId, region, endpoint);
+            final List<String> missingPermissions = awsPermissionChecker.getMissingPermissions(fleet);
+            // TODO: DryRun does not work as expected for TerminateInstances and does not exists for UpdateAutoScalingGroup
+            final String disclaimer = String.format("Skipping validation for following permissions: %s, %s",
+                    AwsPermissionChecker.FleetAPI.TerminateInstances,
+                    AwsPermissionChecker.FleetAPI.UpdateAutoScalingGroup);
+            if(missingPermissions.isEmpty()) {
+                return FormValidation.ok(String.format("Success! %s", disclaimer));
             }
-            return FormValidation.ok("Success");
+            final String errorMessage = String.format("Following AWS permissions are missing: %s ", String.join(", ", missingPermissions));
+            LOGGER.log(Level.WARNING, String.format("[TestConnection] %s", errorMessage));
+            return FormValidation.error(String.format("%s %n %s", errorMessage, disclaimer));
         }
 
         @Override

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleets.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleets.java
@@ -1,6 +1,7 @@
 package com.amazon.jenkins.ec2fleet.fleet;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
 import java.util.Arrays;
@@ -28,11 +29,15 @@ public class EC2Fleets {
     public static EC2Fleet get(final String id) {
         if (GET != null) return GET;
 
-        if (id.startsWith(EC2_SPOT_FLEET_PREFIX)) {
+        if (isEC2Fleet(id)) {
             return EC2_SPOT_FLEET;
         } else {
             return new AutoScalingGroupFleet();
         }
+    }
+
+    public static boolean isEC2Fleet(final String fleet) {
+        return StringUtils.startsWith(fleet, EC2_SPOT_FLEET_PREFIX);
     }
 
     @VisibleForTesting

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-fleet.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-fleet.html
@@ -15,3 +15,8 @@ supported.
     If you are not sure about your fleet check its type by API or
     check if <code>Maintain target capacity</code> enabled in UI for this spot fleet.
 </p>
+<p>
+    <b>AWS Permissions: </b> Plugin requires certain AWS permissions for managing resources. You can check missing permissions by clicking <b>Test Connection</b> button.
+    Test Connection button does not validate certain listed permissions such as TerminateInstances and UpdateAutoScalingGroup due to API restrictions.
+    Check out <a href="https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/README.md"> README</a> for inline IAM Policy.
+</p>


### PR DESCRIPTION
By clicking 'Test Connections' button, users can verify if they are missing any AWS policies required by the plugin.  