### PR TITLE
Upgrade ssh-slave to 1.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>ssh-slaves</artifactId>
-      <version>1.20</version>
+      <version>1.23</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The issue related to class instantiation for TrileadSupport was resolved in ssh-slave 1.23.

More details here: https://issues.jenkins-ci.org/browse/JENKINS-44893