### PR TITLE
Fix executable resubmission behavior on instance termination

### DIFF
--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -115,33 +115,25 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
     }
 
     @Test
-    public void afterDisconnect_should_do_nothing_if_task_finished_without_cause() {
-        new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
-                .afterDisconnect(computer, taskListener);
-        verifyZeroInteractions(queue);
-    }
-
-    @Test
-    public void afterDisconnect_should_do_nothing_if_task_finished_offline_but_no_cause() {
-        when(computer.isOffline()).thenReturn(true);
-        new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
-                .afterDisconnect(computer, taskListener);
-        verifyZeroInteractions(queue);
-    }
-
-    @Test
-    public void afterDisconnect_should_do_nothing_if_task_finished_cause_but_still_online() {
+    public void afterDisconnect_should_do_nothing_if_still_online() {
         when(computer.isOffline()).thenReturn(false);
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verifyZeroInteractions(queue);
     }
 
     @Test
-    public void taskCompleted_should_resubmit_task_if_offline_and_cause_disconnect() {
+    public void afterDisconnect_should_do_nothing_if_offline_but_no_executable() {
         when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
+        when(executor1.getCurrentExecutable()).thenReturn(null);
+        new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
+                .afterDisconnect(computer, taskListener);
+        verifyZeroInteractions(queue);
+    }
+
+    @Test
+    public void taskCompleted_should_resubmit_task_if_offline_and_has_executable() {
+        when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verify(queue).schedule2(eq(task1), anyInt(), eq(Collections.<Action>emptyList()));
@@ -149,10 +141,9 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
     }
 
     @Test
-    public void taskCompleted_should_not_resubmit_task_if_offline_and_cause_disconnect_but_disabled() {
+    public void taskCompleted_should_not_resubmit_task_if_offline_but_disabled() {
         when(cloud.isDisableTaskResubmit()).thenReturn(true);
         when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verifyZeroInteractions(queue);
@@ -160,7 +151,6 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
 
     @Test
     public void taskCompleted_should_resubmit_task_for_all_executors() {
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verify(queue).schedule2(eq(task1), anyInt(), eq(Collections.<Action>emptyList()));
@@ -170,7 +160,6 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
 
     @Test
     public void taskCompleted_should_abort_executors_during_resubmit() {
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verify(executor1).interrupt(Result.ABORTED, new EC2TerminationCause("i-12"));
@@ -181,7 +170,6 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
     public void taskCompleted_should_resubmit_task_with_actions() {
         when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
         when(executable1.getActions()).thenReturn(Arrays.asList(action1));
-        when(computer.getOfflineCause()).thenReturn(new OfflineCause.ChannelTermination(null));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)
                 .afterDisconnect(computer, taskListener);
         verify(queue).schedule2(eq(task1), anyInt(), eq(Arrays.asList(action1)));


### PR DESCRIPTION
`computer.getOfflineCause() instanceof OfflineCause.ChannelTermination` does not always hold after an unexpected instance termination.

As reported in issue #121, the offline cause is sometimes simply `hudson.slaves.OfflineCause$SimpleOfflineCause`; this led to executables running on interrupted instances not always being resubmitted.

Rather than handling specific offline causes (and having to enumerate all possibilities), this commit makes it so that active executables are always resubmitted regardless of the host's offline cause (unless `disableTaskResubmit` is specified). This really does seem like the intended behavior - to ensure executables don't require manual intervention in the event the host they're running on goes offline.
