### PR TITLE
Replace deprecated getInstance() with get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
 )
  
 // get Jenkins instance
-Jenkins jenkins = Jenkins.getInstance()
+Jenkins jenkins = Jenkins.get()
 // get credentials domain
 def domain = Domain.global()
 // get credentials store

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
@@ -29,7 +29,7 @@ public class CloudFormationApi {
 
     public AmazonCloudFormation connect(final String awsCredentialsId, final String regionName, final String endpoint) {
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
         final AmazonCloudFormation client =
                 credentials != null ?
                         new AmazonCloudFormationClient(credentials, clientConfiguration) :

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -171,7 +171,7 @@ public class EC2Api {
 
     public AmazonEC2 connect(final String awsCredentialsId, final String regionName, final String endpoint) {
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
         final AmazonEC2Client client =
                 credentials != null ?
                         new AmazonEC2Client(credentials, clientConfiguration) :

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -453,7 +453,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 final Iterator<NodeProvisioner.PlannedNode> iterator = plannedNodesCache.iterator();
                 final NodeProvisioner.PlannedNode plannedNodeToCancel = iterator.next();
                 iterator.remove();
-                // cancel to let jenkins no that node is not valid any more
+                // cancel to let jenkins know that the node is not valid anymore
                 plannedNodeToCancel.future.cancel(true);
             }
             return stats;
@@ -463,7 +463,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     private void updateByState(
             final int currentToAdd, final Set<String> currentInstanceIdsToTerminate,
             final int targetCapacity, final FleetStateStats newStatus) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
 
         final AmazonEC2 ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
 
@@ -644,7 +644,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     }
 
     private void removeNode(final String instanceId) {
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         // If this node is dying, remove it from Jenkins
         final Node n = jenkins.getNode(instanceId);
         if (n != null) {
@@ -705,7 +705,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         // Initialize our retention strategy
         node.setRetentionStrategy(new IdleRetentionStrategy());
 
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         // jenkins automatically remove old node with same name if any
         jenkins.addNode(node);
 
@@ -761,11 +761,11 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
 
         public List getComputerConnectorDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(ComputerConnector.class);
+            return Jenkins.get().getDescriptorList(ComputerConnector.class);
         }
 
         public ListBoxModel doFillAwsCredentialsIdItems() {
-            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getInstance());
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.get());
         }
 
         public ListBoxModel doFillRegionItems(@QueryParameter final String awsCredentialsId) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -647,7 +647,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         // Initialize our retention strategy
         node.setRetentionStrategy(new IdleRetentionStrategy());
 
-        final Jenkins jenkins = Jenkins.getInstance();
+        final Jenkins jenkins = Jenkins.get();
         // jenkins automatically remove old node with same name if any
         jenkins.addNode(node);
 
@@ -816,11 +816,11 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         }
 
         public List getComputerConnectorDescriptors() {
-            return Jenkins.getInstance().getDescriptorList(ComputerConnector.class);
+            return Jenkins.get().getDescriptorList(ComputerConnector.class);
         }
 
         public ListBoxModel doFillAwsCredentialsIdItems() {
-            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getInstance());
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.get());
         }
 
         public ListBoxModel doFillRegionItems(@QueryParameter final String awsCredentialsId) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -74,7 +74,7 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
 
     @VisibleForTesting
     protected List<Cloud> getClouds() {
-        return Jenkins.getInstance().clouds;
+        return Jenkins.get().clouds;
     }
 
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -101,7 +101,7 @@ public class AutoScalingGroupFleet implements EC2Fleet {
 
     public AmazonAutoScalingClient createClient(
             final String awsCredentialsId, final String regionName, final String endpoint) {
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
         final AmazonAutoScalingClient client =
                 credentials != null ?

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -92,7 +92,7 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
         when(computer.getDisplayName()).thenReturn("i-12");
 
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -134,7 +134,7 @@ public class EC2FleetCloudTest {
         PowerMockito.mockStatic(LabelFinder.class);
 
         PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
     }
 
     @After
@@ -1665,7 +1665,7 @@ public class EC2FleetCloudTest {
         when(labelFinder.iterator()).thenReturn(Collections.emptyIterator());
         PowerMockito.when(LabelFinder.all()).thenReturn(labelFinder);
 
-        // mocking part of node creation process Jenkins.getInstance().getLabelAtom(l)
+        // mocking part of node creation process Jenkins.get().getLabelAtom(l)
         when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
@@ -34,7 +34,7 @@ public class EC2FleetNodeComputerTest {
     @Before
     public void before() {
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
@@ -45,7 +45,7 @@ public class EC2FleetOnlineCheckerTest {
 
         PowerMockito.mockStatic(Jenkins.class);
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
 
         // final method
         PowerMockito.when(node.toComputer()).thenReturn(computer);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -58,7 +58,7 @@ public class AutoScalingGroupFleetTest {
         mockStatic(AWSUtils.class);
         mockStatic(AWSCredentialsHelper.class);
         mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(AWSUtils.getClientConfiguration(ENDPOINT)).thenReturn(clientConfiguration);
     }
 
@@ -161,7 +161,7 @@ public class AutoScalingGroupFleetTest {
         final int min = 1;
         final int max = 5;
 
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
 
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         ListBoxModel listBoxModel = new ListBoxModel();
@@ -186,7 +186,7 @@ public class AutoScalingGroupFleetTest {
 
     @Test (expected = IllegalArgumentException.class)
     public void getFleetStateStatesWithEmptyASGs() throws Exception {
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         PowerMockito.whenNew(AmazonAutoScalingClient.class)
                 .withArguments(amazonWebServicesCredentials, clientConfiguration)
@@ -205,7 +205,7 @@ public class AutoScalingGroupFleetTest {
     @Test
     public void getFleetStateStates() throws Exception {
         final int desiredCapacity = 5;
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.get()).thenReturn(jenkins);
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         PowerMockito.whenNew(AmazonAutoScalingClient.class)
                 .withArguments(amazonWebServicesCredentials, clientConfiguration)


### PR DESCRIPTION
`getInstance()` is deprecated, we should use `get()`

Technically `getInstanceOrNull()` is the true new equivalent to `getInstance()`, but we shouldn't have any problem using just `get()` since we never handle null Jenkins.

In their own words from the `getInstanceOrNull` javadoc: 

>  {@link #get} is what you normally want.
    <p>In certain rare cases you may have code that is intended to run before Jenkins starts or while Jenkins is being shut down.
    For those rare cases use this method.