### PR TITLE
Add .getInstance mock back to EC2Fleet test

### DIFF
--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -93,6 +93,7 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
 
         PowerMockito.mockStatic(Jenkins.class);
         when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -135,6 +135,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.mockStatic(Jenkins.class);
         PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
     }
 
     @After

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
@@ -35,6 +35,7 @@ public class EC2FleetNodeComputerTest {
     public void before() {
         PowerMockito.mockStatic(Jenkins.class);
         when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);


### PR DESCRIPTION
The version of Jenkins we use still calls `.getInstance()` in some places. We still need to mock those or the tests break