### PR TITLE
Remove unused fields from LabelCloud constuctor

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -125,8 +125,6 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                               final String awsCredentialsId,
                               final String region,
                               final String endpoint,
-                              final String fleet,
-                              final String labelString,
                               final String fsRoot,
                               final ComputerConnector computerConnector,
                               final boolean privateIpUsed,
@@ -139,7 +137,6 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                               final boolean disableTaskResubmit,
                               final Integer initOnlineTimeoutSec,
                               final Integer initOnlineCheckIntervalSec,
-                              final boolean scaleExecutorsByWeight,
                               final Integer cloudStatusIntervalSec,
                               final boolean noDelayProvision,
                               final String ec2KeyPairName) {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloudIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloudIntegrationTest.java
@@ -30,9 +30,9 @@ public class EC2FleetLabelCloudIntegrationTest extends IntegrationTest {
         mockCloudFormationApi();
 
         EC2FleetLabelCloud cloud = new EC2FleetLabelCloud("FleetLabel", null, "credId", "region",
-                null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
+                null, null, new LocalComputerConnector(j), false, false,
                 0, 0, 0, 1, false,
-                false, 0, 0, false,
+                false, 0, 0,
                 2, false, "test1");
         j.jenkins.clouds.add(cloud);
 
@@ -59,9 +59,9 @@ public class EC2FleetLabelCloudIntegrationTest extends IntegrationTest {
         final AmazonCloudFormation amazonCloudFormation = mockCloudFormationApi();
 
         EC2FleetLabelCloud cloud = new EC2FleetLabelCloud("FleetLabel", null, "credId", "region",
-                null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
+                null, null, new LocalComputerConnector(j), false, false,
                 0, 0, 0, 1, false,
-                false, 0, 0, false,
+                false, 0, 0,
                 2, false, "test1");
         j.jenkins.clouds.add(cloud);
 


### PR DESCRIPTION
Fixes #235 

These aren't used or displayed in the label fleet configuration