### PR TITLE
Fix tests, revert #237

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
 )
  
 // get Jenkins instance
-Jenkins jenkins = Jenkins.get()
+Jenkins jenkins = Jenkins.getInstance()
 // get credentials domain
 def domain = Domain.global()
 // get credentials store

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudFormationApi.java
@@ -29,7 +29,7 @@ public class CloudFormationApi {
 
     public AmazonCloudFormation connect(final String awsCredentialsId, final String regionName, final String endpoint) {
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
         final AmazonCloudFormation client =
                 credentials != null ?
                         new AmazonCloudFormationClient(credentials, clientConfiguration) :

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2Api.java
@@ -171,7 +171,7 @@ public class EC2Api {
 
     public AmazonEC2 connect(final String awsCredentialsId, final String regionName, final String endpoint) {
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
         final AmazonEC2Client client =
                 credentials != null ?
                         new AmazonEC2Client(credentials, clientConfiguration) :

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -463,7 +463,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     private void updateByState(
             final int currentToAdd, final Set<String> currentInstanceIdsToTerminate,
             final int targetCapacity, final FleetStateStats newStatus) {
-        final Jenkins jenkins = Jenkins.get();
+        final Jenkins jenkins = Jenkins.getInstance();
 
         final AmazonEC2 ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
 
@@ -644,7 +644,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     }
 
     private void removeNode(final String instanceId) {
-        final Jenkins jenkins = Jenkins.get();
+        final Jenkins jenkins = Jenkins.getInstance();
         // If this node is dying, remove it from Jenkins
         final Node n = jenkins.getNode(instanceId);
         if (n != null) {
@@ -705,7 +705,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         // Initialize our retention strategy
         node.setRetentionStrategy(new IdleRetentionStrategy());
 
-        final Jenkins jenkins = Jenkins.get();
+        final Jenkins jenkins = Jenkins.getInstance();
         // jenkins automatically remove old node with same name if any
         jenkins.addNode(node);
 
@@ -761,11 +761,11 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
 
         public List getComputerConnectorDescriptors() {
-            return Jenkins.get().getDescriptorList(ComputerConnector.class);
+            return Jenkins.getInstance().getDescriptorList(ComputerConnector.class);
         }
 
         public ListBoxModel doFillAwsCredentialsIdItems() {
-            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.get());
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getInstance());
         }
 
         public ListBoxModel doFillRegionItems(@QueryParameter final String awsCredentialsId) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -644,7 +644,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         // Initialize our retention strategy
         node.setRetentionStrategy(new IdleRetentionStrategy());
 
-        final Jenkins jenkins = Jenkins.get();
+        final Jenkins jenkins = Jenkins.getInstance();
         // jenkins automatically remove old node with same name if any
         jenkins.addNode(node);
 
@@ -813,11 +813,11 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         }
 
         public List getComputerConnectorDescriptors() {
-            return Jenkins.get().getDescriptorList(ComputerConnector.class);
+            return Jenkins.getInstance().getDescriptorList(ComputerConnector.class);
         }
 
         public ListBoxModel doFillAwsCredentialsIdItems() {
-            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.get());
+            return AWSCredentialsHelper.doFillCredentialsIdItems(Jenkins.getInstance());
         }
 
         public ListBoxModel doFillRegionItems(@QueryParameter final String awsCredentialsId) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -74,7 +74,7 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
 
     @VisibleForTesting
     protected List<Cloud> getClouds() {
-        return Jenkins.get().clouds;
+        return Jenkins.getInstance().clouds;
     }
 
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -101,7 +101,7 @@ public class AutoScalingGroupFleet implements EC2Fleet {
 
     public AmazonAutoScalingClient createClient(
             final String awsCredentialsId, final String regionName, final String endpoint) {
-        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.get());
+        final AmazonWebServicesCredentials credentials = AWSCredentialsHelper.getCredentials(awsCredentialsId, Jenkins.getInstance());
         final ClientConfiguration clientConfiguration = AWSUtils.getClientConfiguration(endpoint);
         final AmazonAutoScalingClient client =
                 credentials != null ?

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -92,7 +92,7 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
         when(computer.getDisplayName()).thenReturn("i-12");
 
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -134,7 +134,7 @@ public class EC2FleetCloudTest {
         PowerMockito.mockStatic(LabelFinder.class);
 
         PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.get()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
     }
 
     @After
@@ -1419,18 +1419,18 @@ public class EC2FleetCloudTest {
         when(awsPermissionChecker.getMissingPermissions(null)).thenReturn(new ArrayList<>());
         PowerMockito.whenNew(AwsPermissionChecker.class).withAnyArguments().thenReturn(awsPermissionChecker);
 
-        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection(null, null, null, null);
+        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection("credentials", null, null, null);
 
         Assert.assertTrue(formValidation.getMessage().contains("Success"));
     }
 
     @Test
-    public void descriptorImpl_doTestConnection_missingDecribeInstancePermission() throws Exception {
+    public void descriptorImpl_doTestConnection_missingDescribeInstancePermission() throws Exception {
         final AwsPermissionChecker awsPermissionChecker = mock(AwsPermissionChecker.class);
         when(awsPermissionChecker.getMissingPermissions(null)).thenReturn(Collections.singletonList(AwsPermissionChecker.FleetAPI.DescribeInstances.name()));
         PowerMockito.whenNew(AwsPermissionChecker.class).withAnyArguments().thenReturn(awsPermissionChecker);
 
-        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection(null, null, null, null);
+        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection("credentials", null, null, null);
 
         Assert.assertThat(formValidation.getMessage(), Matchers.containsString(AwsPermissionChecker.FleetAPI.DescribeInstances.name()));
     }
@@ -1445,7 +1445,7 @@ public class EC2FleetCloudTest {
         when(awsPermissionChecker.getMissingPermissions(null)).thenReturn(missingPermissions);
         PowerMockito.whenNew(AwsPermissionChecker.class).withAnyArguments().thenReturn(awsPermissionChecker);
 
-        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection(null, null, null, null);
+        final FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doTestConnection("credentials", null, null, null);
 
         Assert.assertThat(formValidation.getMessage(), Matchers.containsString(AwsPermissionChecker.FleetAPI.DescribeInstances.name()));
         Assert.assertThat(formValidation.getMessage(), Matchers.containsString(AwsPermissionChecker.FleetAPI.CreateTags.name()));
@@ -1665,7 +1665,7 @@ public class EC2FleetCloudTest {
         when(labelFinder.iterator()).thenReturn(Collections.emptyIterator());
         PowerMockito.when(LabelFinder.all()).thenReturn(labelFinder);
 
-        // mocking part of node creation process Jenkins.get().getLabelAtom(l)
+        // mocking part of node creation process Jenkins.getInstance().getLabelAtom(l)
         when(jenkins.getLabelAtom(anyString())).thenReturn(new LabelAtom("mock-label"));
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
@@ -34,7 +34,7 @@ public class EC2FleetNodeComputerTest {
     @Before
     public void before() {
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(Queue.getInstance()).thenReturn(queue);
 
         when(slave.getNumExecutors()).thenReturn(1);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
@@ -45,7 +45,7 @@ public class EC2FleetOnlineCheckerTest {
 
         PowerMockito.mockStatic(Jenkins.class);
 
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
 
         // final method
         PowerMockito.when(node.toComputer()).thenReturn(computer);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -58,7 +58,7 @@ public class AutoScalingGroupFleetTest {
         mockStatic(AWSUtils.class);
         mockStatic(AWSCredentialsHelper.class);
         mockStatic(Jenkins.class);
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(AWSUtils.getClientConfiguration(ENDPOINT)).thenReturn(clientConfiguration);
     }
 
@@ -161,7 +161,7 @@ public class AutoScalingGroupFleetTest {
         final int min = 1;
         final int max = 5;
 
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
 
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         ListBoxModel listBoxModel = new ListBoxModel();
@@ -186,7 +186,7 @@ public class AutoScalingGroupFleetTest {
 
     @Test (expected = IllegalArgumentException.class)
     public void getFleetStateStatesWithEmptyASGs() throws Exception {
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         PowerMockito.whenNew(AmazonAutoScalingClient.class)
                 .withArguments(amazonWebServicesCredentials, clientConfiguration)
@@ -205,7 +205,7 @@ public class AutoScalingGroupFleetTest {
     @Test
     public void getFleetStateStates() throws Exception {
         final int desiredCapacity = 5;
-        when(Jenkins.get()).thenReturn(jenkins);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
         when(AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         PowerMockito.whenNew(AmazonAutoScalingClient.class)
                 .withArguments(amazonWebServicesCredentials, clientConfiguration)


### PR DESCRIPTION
I broke the tests in #237 because we still needed to mock `Jenkins.getInstance()` due to them being used in Jenkins code we don't control 😔

This change reverts that, and should also fix the `descriptorImpl_doTestConnection` tests which have been broken since #225 