### PR TITLE
Get accurate count of active instances

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -571,6 +571,9 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Map<String, Instance> described = Registry.getEc2Api().describeInstances(ec2, fleetInstances);
         info("described instances: %s", described.keySet());
 
+        // Fleet takes a while to display terminated instances. Update stats with current view of active instance count
+        newStatus.setNumActive(described.size());
+
         // currentJenkinsNodes contains all registered Jenkins nodes related to this cloud
         final Set<String> jenkinsInstances = new HashSet<>();
         for (final Node node : jenkins.getNodes()) {
@@ -679,7 +682,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
 
         // We can't remove instances beyond minSize
-        if (minSize > 0 && stats.getNumDesired() - instanceIdsToTerminate.size() <= minSize) {
+        if (minSize > 0 && stats.getNumActive() - instanceIdsToTerminate.size() <= minSize) {
             info("Not terminating %s because we need a minimum of %s instances running.", instanceId, minSize);
             return false;
         }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/FleetStateStats.java
@@ -106,7 +106,7 @@ public final class FleetStateStats {
     @Nonnull
     private final String fleetId;
     @Nonnegative
-    private final int numActive;
+    private int numActive;
     @Nonnegative
     private final int numDesired;
     @Nonnull
@@ -145,6 +145,11 @@ public final class FleetStateStats {
 
     public int getNumActive() {
         return numActive;
+    }
+
+    // Fleet does not immediately display the active instances and syncs up eventually
+    public void setNumActive(final int activeCount) {
+        numActive = activeCount;
     }
 
     public int getNumDesired() {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -416,7 +416,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 1, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                ImmutableSet.of("z"), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
@@ -441,7 +441,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                ImmutableSet.of("z", "z1"), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
@@ -467,7 +467,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                ImmutableSet.of("z-1", "z-2"), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r1 = fleetCloud.scheduleToTerminate("z-1");
@@ -495,7 +495,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 3, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                ImmutableSet.of("z1", "z2", "z3"), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r1 = fleetCloud.scheduleToTerminate("z1");


### PR DESCRIPTION
Get accurate count of instance before scheduling instances for termination. Some scenarios where this is needed:

1. Fleet takes a while to reflect the accurate count which can cause us to go below min threshold
2. Failed termination - Fleet may have target of 0 however there may be instances strangling around (due to termination policy) which would never get deleted. Although, we would add them as Jenkins nodes but these could never really be removed.
This change would help us have accurate count of active instances based on true state of the world