### PR TITLE
Fix bug when stats is null for termination

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -208,6 +208,9 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         this.noDelayProvision = noDelayProvision;
 
         if (StringUtils.isNotEmpty(oldId)) {
+            id.setValue(oldId);
+            this.stats = EC2Fleets.get(fleet).getState(
+                    getAwsCredentialsId(), region, endpoint, getFleet());
             // existent cloud was modified, let's re-assign all dependencies of old cloud instance
             // to new one
             EC2FleetCloudAwareUtils.reassign(oldId, this);

--- a/src/main/java/com/amazon/jenkins/ec2fleet/LazyUuid.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/LazyUuid.java
@@ -19,4 +19,7 @@ public class LazyUuid {
         return value;
     }
 
+    public synchronized void setValue(String value) {
+        this.value = value;
+    }
 }


### PR DESCRIPTION
When user changes plugin config such as `numOfExecutor`, Jenkins creates a new instance and we reassign the `new Cloud` back to existing nodes/computers. However, during initialization of `new Cloud`, the `stats` object remains null and we reassign the null stats to existing cloud. This causes termination to fail. 

When the user clicks save multiple times, we lose the `id.getValue` which causes `IdleRetentionStrategy` thread and `CloudNanny` thread to have different copies of objects. In this scenario, we might add instances to `instancesToTerminate` list however `CloudNanny` continues to refer to newer object. 