### PR TITLE
Change location of a log to avoid spam

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -613,7 +613,6 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         jenkinsNodesToRemove.addAll(jenkinsNodesWithoutInstance);
         // Remove dying fleet instances from Jenkins
         for (final String instance : jenkinsNodesToRemove) {
-            info("Fleet (" + getLabelString() + ") no longer has the instance " + instance + ", removing from Jenkins.");
             removeNode(instance);
         }
 
@@ -722,6 +721,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Node n = jenkins.getNode(instanceId);
         if (n != null) {
             try {
+                info("Fleet (" + getLabelString() + ") no longer has the instance " + instanceId + ", removing from Jenkins.");
                 jenkins.removeNode(n);
             } catch (final Exception ex) {
                 throw new IllegalStateException(String.format("Error removing node %s", instanceId), ex);


### PR DESCRIPTION
After an instance is requested for termination it will still show up for a while until it's fully removed from the fleet. During that time, this log message shows up ever `update`, even though Jenkins has already removed the node. This change just moves the log statement so that if Jenkins has already removed the node, we don't emit this. 