### PR TITLE
[JENKINS-66310] Prepare EC2 Fleet for core Guava upgrade

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdater.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdater.java
@@ -1,6 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.PeriodicWork;
 import hudson.slaves.Cloud;
@@ -54,7 +53,6 @@ public class EC2FleetStatusWidgetUpdater extends PeriodicWork {
      *
      * @return widgets
      */
-    @VisibleForTesting
     private static List<Widget> getWidgets() {
         return Jenkins.getActiveInstance().getWidgets();
     }
@@ -65,7 +63,6 @@ public class EC2FleetStatusWidgetUpdater extends PeriodicWork {
      *
      * @return basic java list
      */
-    @VisibleForTesting
     private static List<Cloud> getClouds() {
         return Jenkins.getActiveInstance().clouds;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -1,6 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.annotations.VisibleForTesting;
 import hudson.Extension;
 import hudson.model.Label;
 import hudson.model.LoadStatistics;
@@ -89,7 +88,7 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
         }
     }
 
-    @VisibleForTesting
+    // Visible for testing
     protected List<Cloud> getClouds() {
         return Jenkins.getInstance().clouds;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleets.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/EC2Fleets.java
@@ -1,6 +1,5 @@
 package com.amazon.jenkins.ec2fleet.fleet;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -40,7 +39,7 @@ public class EC2Fleets {
         return StringUtils.startsWith(fleet, EC2_SPOT_FLEET_PREFIX);
     }
 
-    @VisibleForTesting
+    // Visible for testing
     public static void setGet(EC2Fleet ec2Fleet) {
         GET = ec2Fleet;
     }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -9,7 +9,6 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceState;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
-import com.google.common.collect.ImmutableSet;
 import hudson.Functions;
 import hudson.model.FreeStyleProject;
 import hudson.model.Node;
@@ -53,7 +52,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
         Registry.setEc2Api(ec2Api);
 
         when(ec2Fleet.getState(anyString(), anyString(), nullable(String.class), anyString())).thenReturn(
-                new FleetStateStats("", 1, FleetStateStats.State.active(), ImmutableSet.of("i-1"),
+                new FleetStateStats("", 1, FleetStateStats.State.active(), Collections.singleton("i-1"),
                         Collections.<String, Double>emptyMap()));
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNannyTest.java
@@ -1,7 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.MapMaker;
 import hudson.slaves.Cloud;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +13,8 @@ import org.powermock.reflect.Whitebox;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
+import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
@@ -39,20 +38,17 @@ public class CloudNannyTest {
     private List<Cloud> clouds = new ArrayList<>();
 
     private FleetStateStats stats1 = new FleetStateStats(
-            "f1", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f1", 1, new FleetStateStats.State(true, false, "a"), Collections.emptySet(), Collections.<String, Double>emptyMap());
 
     private FleetStateStats stats2 = new FleetStateStats(
-            "f2", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f2", 1, new FleetStateStats.State(true, false, "a"), Collections.emptySet(), Collections.<String, Double>emptyMap());
 
     private int recurrencePeriod = 45;
 
     private AtomicInteger recurrenceCounter1 = new AtomicInteger();
     private AtomicInteger recurrenceCounter2 = new AtomicInteger();
 
-    private ConcurrentMap<EC2FleetCloud, AtomicInteger> recurrenceCounters = new MapMaker()
-            .weakKeys()
-            .concurrencyLevel(2)
-            .makeMap();
+    private Map<EC2FleetCloud, AtomicInteger> recurrenceCounters = Collections.synchronizedMap(new WeakHashMap<>());
 
     @Before
     public void before() throws Exception {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2ApiTest.java
@@ -11,8 +11,6 @@ import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.Tag;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +20,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +71,10 @@ public class EC2ApiTest {
         Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(ImmutableMap.of("i-1", instance1, "i-2", instance2), described);
+        Map<String, Instance> expected = new HashMap<>();
+        expected.put("i-1", instance1);
+        expected.put("i-2", instance2);
+        Assert.assertEquals(expected, described);
         verify(amazonEC2, times(1))
                 .describeInstances(any(DescribeInstancesRequest.class));
     }
@@ -135,7 +137,10 @@ public class EC2ApiTest {
         Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(ImmutableMap.of("i-1", instance1, "i-2", instance2), described);
+        Map<String, Instance> expected = new HashMap<>();
+        expected.put("i-1", instance1);
+        expected.put("i-2", instance2);
+        Assert.assertEquals(expected, described);
         verify(amazonEC2, times(2))
                 .describeInstances(any(DescribeInstancesRequest.class));
     }
@@ -260,7 +265,7 @@ public class EC2ApiTest {
         final Map<String, Instance> described = new EC2Api().describeInstances(amazonEC2, instanceIds);
 
         // then
-        Assert.assertEquals(ImmutableMap.of("i-3", instance3), described);
+        Assert.assertEquals(Collections.singletonMap("i-3", instance3), described);
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-1", "i-3", "i-f")));
         verify(amazonEC2).describeInstances(new DescribeInstancesRequest().withInstanceIds(Arrays.asList("i-3")));
         verifyNoMoreInteractions(amazonEC2);
@@ -321,11 +326,11 @@ public class EC2ApiTest {
     @Test
     public void tagInstances_shouldTag() {
         // when
-        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa", "v");
+        new EC2Api().tagInstances(amazonEC2, new HashSet<>(Arrays.asList("i-1", "i-2")), "opa", "v");
 
         // then
         verify(amazonEC2).createTags(new CreateTagsRequest()
-                .withResources(ImmutableSet.of("i-1", "i-2"))
+                .withResources(new HashSet<>(Arrays.asList("i-1", "i-2")))
                 .withTags(new Tag().withKey("opa").withValue("v")));
         verifyNoMoreInteractions(amazonEC2);
     }
@@ -333,11 +338,11 @@ public class EC2ApiTest {
     @Test
     public void tagInstances_givenNullValueShouldTagWithEmptyValue() {
         // when
-        new EC2Api().tagInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"), "opa", null);
+        new EC2Api().tagInstances(amazonEC2, new HashSet<>(Arrays.asList("i-1", "i-2")), "opa", null);
 
         // then
         verify(amazonEC2).createTags(new CreateTagsRequest()
-                .withResources(ImmutableSet.of("i-1", "i-2"))
+                .withResources(new HashSet<>(Arrays.asList("i-1", "i-2")))
                 .withTags(new Tag().withKey("opa").withValue("")));
         verifyNoMoreInteractions(amazonEC2);
     }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -16,8 +16,6 @@ import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Region;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import hudson.ExtensionList;
 import hudson.model.LabelFinder;
 import hudson.model.Node;
@@ -417,7 +415,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 1, FleetStateStats.State.active(),
-                ImmutableSet.of("z"), Collections.<String, Double>emptyMap()));
+                Collections.singleton("z"), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
@@ -442,14 +440,14 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, FleetStateStats.State.active(),
-                ImmutableSet.of("z", "z1"), Collections.<String, Double>emptyMap()));
+                new HashSet<>(Arrays.asList("z", "z1")), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r = fleetCloud.scheduleToTerminate("z");
 
         // then
         assertTrue(r);
-        assertEquals(ImmutableSet.of("z"), fleetCloud.getInstanceIdsToTerminate());
+        assertEquals(Collections.singleton("z"), fleetCloud.getInstanceIdsToTerminate());
     }
 
     @Test
@@ -468,7 +466,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 2, FleetStateStats.State.active(),
-                ImmutableSet.of("z-1", "z-2"), Collections.<String, Double>emptyMap()));
+                new HashSet<>(Arrays.asList("z-1", "z-2")), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r1 = fleetCloud.scheduleToTerminate("z-1");
@@ -477,7 +475,7 @@ public class EC2FleetCloudTest {
         // then
         assertTrue(r1);
         assertTrue(r2);
-        assertEquals(ImmutableSet.of("z-1", "z-2"), fleetCloud.getInstanceIdsToTerminate());
+        assertEquals(new HashSet<>(Arrays.asList("z-1", "z-2")), fleetCloud.getInstanceIdsToTerminate());
     }
 
     @Test
@@ -496,7 +494,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         fleetCloud.setStats(new FleetStateStats("", 3, FleetStateStats.State.active(),
-                ImmutableSet.of("z1", "z2", "z3"), Collections.<String, Double>emptyMap()));
+                new HashSet<>(Arrays.asList("z1", "z2", "z3")), Collections.<String, Double>emptyMap()));
 
         // when
         boolean r1 = fleetCloud.scheduleToTerminate("z1");
@@ -507,7 +505,7 @@ public class EC2FleetCloudTest {
         assertTrue(r1);
         assertTrue(r2);
         assertFalse(r3);
-        assertEquals(ImmutableSet.of("z1", "z2"), fleetCloud.getInstanceIdsToTerminate());
+        assertEquals(new HashSet<>(Arrays.asList("z1", "z2")), fleetCloud.getInstanceIdsToTerminate());
     }
 
     @Test
@@ -678,7 +676,7 @@ public class EC2FleetCloudTest {
 
         // then
         verify(ec2Fleet).modify(anyString(), anyString(), anyString(), eq("fleetId"), eq(2), eq(0), eq(10));
-        verify(ec2Api).terminateInstances(amazonEC2, ImmutableSet.of("i-1", "i-2"));
+        verify(ec2Api).terminateInstances(amazonEC2, new HashSet<>(Arrays.asList("i-1", "i-2")));
     }
 
     @Test
@@ -698,7 +696,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0"), Collections.<String, Double>emptyMap()));
+                        Collections.singleton("i-0"), Collections.<String, Double>emptyMap()));
 
         mockNodeCreatingPart();
 
@@ -740,7 +738,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0", "i-1"), Collections.<String, Double>emptyMap()));
+                        new HashSet<>(Arrays.asList("i-0", "i-1")), Collections.<String, Double>emptyMap()));
 
         mockNodeCreatingPart();
 
@@ -757,7 +755,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0", "i-1"), "ec2-fleet-plugin:cloud-name", "FleetCloud");
+        verify(ec2Api).tagInstances(amazonEC2, new HashSet<>(Arrays.asList("i-0", "i-1")), "ec2-fleet-plugin:cloud-name", "FleetCloud");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
@@ -776,7 +774,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0"), Collections.<String, Double>emptyMap()));
+                        Collections.singleton("i-0"), Collections.<String, Double>emptyMap()));
 
         mockNodeCreatingPart();
 
@@ -793,7 +791,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin:cloud-name", "my-fleet");
+        verify(ec2Api).tagInstances(amazonEC2, Collections.singleton("i-0"), "ec2-fleet-plugin:cloud-name", "my-fleet");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
@@ -817,7 +815,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0"), Collections.<String, Double>emptyMap()));
+                        Collections.singleton("i-0"), Collections.<String, Double>emptyMap()));
 
         mockNodeCreatingPart();
 
@@ -834,7 +832,7 @@ public class EC2FleetCloudTest {
         fleetCloud.update();
 
         // then
-        verify(ec2Api).tagInstances(amazonEC2, ImmutableSet.of("i-0"), "ec2-fleet-plugin:cloud-name", "FleetCloud");
+        verify(ec2Api).tagInstances(amazonEC2, Collections.singleton("i-0"), "ec2-fleet-plugin:cloud-name", "FleetCloud");
         Node actualFleetNode = nodeCaptor.getValue();
         assertEquals(Node.Mode.NORMAL, actualFleetNode.getMode());
     }
@@ -846,7 +844,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0"), Collections.<String, Double>emptyMap()));
+                        Collections.singleton("i-0"), Collections.<String, Double>emptyMap()));
 
         final Instance instance = new Instance()
                 .withPublicIpAddress("p-ip")
@@ -899,8 +897,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of("i-0"),
-                        ImmutableMap.of(instanceType, 1.1)));
+                        Collections.singleton("i-0"),
+                        Collections.singletonMap(instanceType, 1.1)));
 
         mockNodeCreatingPart();
 
@@ -931,7 +929,7 @@ public class EC2FleetCloudTest {
 
         final FleetStateStats initState = new FleetStateStats("fleetId", 0,
                 FleetStateStats.State.active(),
-                ImmutableSet.of("i-0", "i-1"), Collections.<String, Double>emptyMap());
+                new HashSet<>(Arrays.asList("i-0", "i-1")), Collections.<String, Double>emptyMap());
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(initState);
 
@@ -1114,7 +1112,7 @@ public class EC2FleetCloudTest {
 
         final FleetStateStats initState = new FleetStateStats("fleetId", 5,
                 FleetStateStats.State.active(),
-                ImmutableSet.<String>of("i-0"), Collections.<String, Double>emptyMap());
+                Collections.singleton("i-0"), Collections.<String, Double>emptyMap());
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(initState);
 
@@ -1158,8 +1156,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
-                        ImmutableMap.of(instanceType, 2.0)));
+                        Collections.singleton(instanceId),
+                        Collections.singletonMap(instanceType, 2.0)));
 
         mockNodeCreatingPart();
 
@@ -1200,8 +1198,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
-                        ImmutableMap.of("diff-t", 2.0)));
+                        Collections.singleton(instanceId),
+                        Collections.singletonMap("diff-t", 2.0)));
 
         mockNodeCreatingPart();
 
@@ -1242,8 +1240,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
-                        ImmutableMap.of(instanceType, 1.44)));
+                        Collections.singleton(instanceId),
+                        Collections.singletonMap(instanceType, 1.44)));
 
         mockNodeCreatingPart();
 
@@ -1284,8 +1282,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
-                        ImmutableMap.of(instanceType, 1.5)));
+                        Collections.singleton(instanceId),
+                        Collections.singletonMap(instanceType, 1.5)));
 
         mockNodeCreatingPart();
 
@@ -1326,7 +1324,7 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
+                        Collections.singleton(instanceId),
                         Collections.<String, Double>emptyMap()));
 
         PowerMockito.doThrow(new UnsupportedOperationException("Test exception")).when(ec2Fleet)
@@ -1372,8 +1370,8 @@ public class EC2FleetCloudTest {
 
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(new FleetStateStats("fleetId", 0, FleetStateStats.State.active(),
-                        ImmutableSet.of(instanceId),
-                        ImmutableMap.of(instanceType, .1)));
+                        Collections.singleton(instanceId),
+                        Collections.singletonMap(instanceType, .1)));
 
         mockNodeCreatingPart();
 
@@ -1414,14 +1412,14 @@ public class EC2FleetCloudTest {
 
         final FleetStateStats stats = new FleetStateStats("fleetId", 0,
                 FleetStateStats.State.modifying(""),
-                ImmutableSet.of(instanceId),
-                ImmutableMap.of(instanceType, .1));
+                Collections.singleton(instanceId),
+                Collections.singletonMap(instanceType, .1));
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(stats);
 
         final FleetStateStats initialState = new FleetStateStats("fleetId", 0,
                 FleetStateStats.State.active(),
-                ImmutableSet.of(instanceId),
-                ImmutableMap.of(instanceType, .1));
+                Collections.singleton(instanceId),
+                Collections.singletonMap(instanceType, .1));
 
         mockNodeCreatingPart();
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
@@ -1,6 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.util.concurrent.SettableFuture;
 import hudson.model.Computer;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
@@ -14,6 +13,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 @PrepareForTest({EC2FleetOnlineChecker.class, EC2FleetNode.class, Jenkins.class, Computer.class})
 public class EC2FleetOnlineCheckerTest {
 
-    private SettableFuture<Node> future = SettableFuture.create();
+    private CompletableFuture<Node> future = new CompletableFuture<>();
 
     @Mock
     private EC2FleetNode node;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatusWidgetUpdaterTest.java
@@ -1,7 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import hudson.slaves.Cloud;
 import hudson.widgets.Widget;
 import org.junit.Before;
@@ -14,6 +12,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -44,10 +43,10 @@ public class EC2FleetStatusWidgetUpdaterTest {
     private List<Cloud> clouds = new ArrayList<>();
 
     private FleetStateStats stats1 = new FleetStateStats(
-            "f1", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f1", 1, new FleetStateStats.State(true, false, "a"), Collections.emptySet(), Collections.<String, Double>emptyMap());
 
     private FleetStateStats stats2 = new FleetStateStats(
-            "f2", 1, new FleetStateStats.State(true, false, "a"), ImmutableSet.<String>of(), Collections.<String, Double>emptyMap());
+            "f2", 1, new FleetStateStats.State(true, false, "a"), Collections.emptySet(), Collections.<String, Double>emptyMap());
 
     @Before
     public void before() throws Exception {
@@ -107,7 +106,7 @@ public class EC2FleetStatusWidgetUpdaterTest {
 
         getMockEC2FleetStatusWidgetUpdater().doRun();
 
-        verify(widget1).setStatusList(ImmutableList.of(
+        verify(widget1).setStatusList(Arrays.asList(
                 new EC2FleetStatusInfo(cloud1.getFleet(), stats1.getState().getDetailed(), cloud1.getLabelString(), stats1.getNumActive(), stats1.getNumDesired()),
                 new EC2FleetStatusInfo(cloud2.getFleet(), stats2.getState().getDetailed(), cloud2.getLabelString(), stats2.getNumActive(), stats2.getNumDesired())
         ));

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
@@ -11,7 +11,6 @@ import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.amazonaws.services.ec2.model.TerminateInstancesResult;
-import com.google.common.collect.ImmutableSet;
 import hudson.model.queue.QueueTaskFuture;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,7 +18,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertTrue;
@@ -45,7 +46,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         amazonEC2 = mock(AmazonEC2.class);
 
         when(ec2Fleet.getState(anyString(), anyString(), nullable(String.class), anyString()))
-                .thenReturn(new FleetStateStats("", 2, FleetStateStats.State.active(), ImmutableSet.of("i-1", "i-2"), Collections.emptyMap()));
+                .thenReturn(new FleetStateStats("", 2, FleetStateStats.State.active(), new HashSet<>(Arrays.asList("i-1", "i-2")), Collections.emptyMap()));
         when(ec2Api.connect(anyString(), anyString(), Mockito.nullable(String.class))).thenReturn(amazonEC2);
 
         final Instance instance = new Instance()

--- a/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyTest.java
@@ -1,6 +1,5 @@
 package com.amazon.jenkins.ec2fleet;
 
-import com.google.common.util.concurrent.SettableFuture;
 import hudson.model.Label;
 import hudson.model.LoadStatistics;
 import hudson.model.Node;
@@ -17,6 +16,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -161,8 +161,8 @@ public class NoDelayProvisionStrategyTest {
         when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
         when(ec2FleetCloud2.isNoDelayProvision()).thenReturn(true);
         when(ec2FleetCloud1.provision(any(Label.class), anyInt())).thenReturn(Arrays.asList(
-                new NodeProvisioner.PlannedNode("", SettableFuture.<Node>create(), 1),
-                new NodeProvisioner.PlannedNode("", SettableFuture.<Node>create(), 1)
+                new NodeProvisioner.PlannedNode("", new CompletableFuture<>(), 1),
+                new NodeProvisioner.PlannedNode("", new CompletableFuture<>(), 1)
         ));
 
         Assert.assertEquals(
@@ -186,8 +186,8 @@ public class NoDelayProvisionStrategyTest {
         when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
         when(ec2FleetCloud2.isNoDelayProvision()).thenReturn(true);
         when(ec2FleetCloud1.provision(any(Label.class), anyInt())).thenReturn(Arrays.asList(
-                new NodeProvisioner.PlannedNode("", SettableFuture.<Node>create(), 1),
-                new NodeProvisioner.PlannedNode("", SettableFuture.<Node>create(), 1)
+                new NodeProvisioner.PlannedNode("", new CompletableFuture<>(), 1),
+                new NodeProvisioner.PlannedNode("", new CompletableFuture<>(), 1)
         ));
 
         Assert.assertEquals(
@@ -206,7 +206,7 @@ public class NoDelayProvisionStrategyTest {
         clouds.add(ec2FleetCloud1);
         when(ec2FleetCloud1.canProvision(any(Label.class))).thenReturn(true);
         when(ec2FleetCloud1.isNoDelayProvision()).thenReturn(true);
-        final NodeProvisioner.PlannedNode plannedNode = new NodeProvisioner.PlannedNode("", SettableFuture.<Node>create(), 2);
+        final NodeProvisioner.PlannedNode plannedNode = new NodeProvisioner.PlannedNode("", new CompletableFuture<>(), 2);
         when(ec2FleetCloud1.provision(any(Label.class), anyInt())).thenReturn(Arrays.asList(plannedNode));
         // then
         final NodeProvisioner.StrategyDecision decision = strategy.apply(state);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -16,7 +16,6 @@ import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.amazonaws.services.ec2.model.Reservation;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
-import com.google.common.collect.ImmutableSet;
 import hudson.model.Label;
 import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
@@ -32,6 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -72,7 +72,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         EC2Fleets.setGet(ec2Fleet);
 
         when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
-                new FleetStateStats("", 0, FleetStateStats.State.active(), ImmutableSet.<String>of(),
+                new FleetStateStats("", 0, FleetStateStats.State.active(), Collections.emptySet(),
                         Collections.<String, Double>emptyMap()));
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
@@ -265,7 +265,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         tryUntil(new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals(ImmutableSet.of("master", "momo"), labelsToNames(j.jenkins.getLabels()));
+                Assert.assertEquals(new HashSet<>(Arrays.asList("master", "momo")), labelsToNames(j.jenkins.getLabels()));
                 Assert.assertEquals(1, j.jenkins.getLabelAtom("momo").nodeProvisioner.getPendingLaunches().size());
                 Assert.assertEquals(0, j.jenkins.getNodes().size());
             }
@@ -296,10 +296,10 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         tryUntil(new Runnable() {
             @Override
             public void run() {
-                Assert.assertEquals(ImmutableSet.of("master", "momo", "i-0", "i-1"), labelsToNames(j.jenkins.getLabels()));
+                Assert.assertEquals(new HashSet<>(Arrays.asList("master", "momo", "i-0", "i-1")), labelsToNames(j.jenkins.getLabels()));
                 Assert.assertEquals(2, j.jenkins.getLabelAtom("momo").getNodes().size());
                 // node name should be instance name
-                Assert.assertEquals(ImmutableSet.of("i-0", "i-1"), nodeToNames(j.jenkins.getLabelAtom("momo").getNodes()));
+                Assert.assertEquals(new HashSet<>(Arrays.asList("i-0", "i-1")), nodeToNames(j.jenkins.getLabelAtom("momo").getNodes()));
             }
         });
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -9,7 +9,6 @@ import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlFormUtil;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
 import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
-import com.google.common.collect.ImmutableSet;
 import hudson.PluginWrapper;
 import hudson.model.Node;
 import hudson.slaves.Cloud;
@@ -26,7 +25,9 @@ import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -62,7 +63,7 @@ public class UiIntegrationTest {
         final AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
 
         when(ec2Fleet.getState(anyString(), anyString(), nullable(String.class), anyString()))
-                .thenReturn(new FleetStateStats("", 2, FleetStateStats.State.active(), ImmutableSet.of("i-1", "i-2"), Collections.emptyMap()));
+                .thenReturn(new FleetStateStats("", 2, FleetStateStats.State.active(), new HashSet<>(Arrays.asList("i-1", "i-2")), Collections.emptyMap()));
         when(ec2Api.connect(anyString(), anyString(), Mockito.nullable(String.class))).thenReturn(amazonEC2);
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/EC2SpotFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/EC2SpotFleetTest.java
@@ -14,8 +14,6 @@ import com.amazonaws.services.ec2.model.FleetType;
 import com.amazonaws.services.ec2.model.SpotFleetLaunchSpecification;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import hudson.util.ListBoxModel;
 import org.junit.After;
 import org.junit.Assert;
@@ -25,7 +23,11 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -108,7 +110,7 @@ public class EC2SpotFleetTest {
 
         FleetStateStats stats = new EC2SpotFleet().getState("cred", "region", "", "f");
 
-        Assert.assertEquals(ImmutableSet.of("i-1", "i-2"), stats.getInstances());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("i-1", "i-2")), stats.getInstances());
         Assert.assertEquals(2, stats.getNumActive());
         verify(ec2).describeSpotFleetInstances(new DescribeSpotFleetInstancesRequest()
                 .withSpotFleetRequestId("f"));
@@ -125,7 +127,7 @@ public class EC2SpotFleetTest {
 
         FleetStateStats stats = new EC2SpotFleet().getState("cred", "region", "", "f");
 
-        Assert.assertEquals(ImmutableSet.of("i-1", "i-2"), stats.getInstances());
+        Assert.assertEquals(new HashSet<>(Arrays.asList("i-1", "i-2")), stats.getInstances());
         Assert.assertEquals(2, stats.getNumActive());
         verify(ec2).describeSpotFleetInstances(new DescribeSpotFleetInstancesRequest()
                 .withSpotFleetRequestId("f").withNextToken("p1"));
@@ -154,7 +156,10 @@ public class EC2SpotFleetTest {
 
         FleetStateStats stats = new EC2SpotFleet().getState("cred", "region", "", "f");
 
-        Assert.assertEquals(ImmutableMap.of("t1", 0.1, "t2", 12.0), stats.getInstanceTypeWeights());
+        Map<String, Double> expected = new HashMap<>();
+        expected.put("t1", 0.1);
+        expected.put("t2", 12.0);
+        Assert.assertEquals(expected, stats.getInstanceTypeWeights());
     }
 
     @Test


### PR DESCRIPTION
See [JENKINS-66310](https://issues.jenkins.io/browse/JENKINS-66310) and [JENKINS-65988](https://issues.jenkins.io/browse/JENKINS-65988). Jenkins core is using [Guava 11.0.1](https://github.com/google/guava/releases/tag/v11.0.1), which was released on January 9, 2012. Jenkins core would like to upgrade to [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), which was released on March 19, 2021. Plugins must be prepared to be compatible with both Guava 11.0.1 and Guava 30.1.1 in advance of this core transition.

In particular, this plugin has been identified as using the `com.google.common.collect.MapMaker` API, which has changed between Guava [11.0.1](https://guava.dev/releases/11.0.1/api/docs/com/google/common/collect/MapMaker.html) and [latest](https://guava.dev/releases/snapshot-jre/api/docs/com/google/common/collect/MapMaker.html). In particular, the following methods have been removed:

 * `MapMaker#expiration(long duration, TimeUnit unit)` 
 * `MapMaker#makeComputingMap(Function<? super K,? extends V> computingFunction)`
 * `MapMaker#softKeys()`
 * `MapMaker#softValues()`

To facilitate the Jenkins core transition, this plugin must be prepared and released such that it works with both Guava 11.0.1 and latest. This implies migrating away from the `MapMaker` API.

This PR replaces any and all usages of Guava in this plugin with the equivalent functionality from the Java Platform. This allows Jenkins core to upgrade Guava without affecting this plugin.