### PR TITLE
increase test sleep time from 60s to 61s

### DIFF
--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
@@ -81,7 +81,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -119,7 +119,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -146,7 +146,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -175,7 +175,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         assertAtLeastOneNode();
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {


### PR DESCRIPTION
From a failed pipeline test: 

<img width="1013" alt="image" src="https://user-images.githubusercontent.com/56001173/132738919-402e4a92-2d82-4518-a3ae-7e65f10912eb.png">

😩

Adding a second to the sleep so that `idleTime > retentionTime` and the nodes get marked as idle as intended