### PR TITLE
Increase test sleep time

### DIFF
--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
@@ -81,7 +81,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -119,7 +119,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -146,7 +146,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {
@@ -175,7 +175,7 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         assertAtLeastOneNode();
 
         // Nodes take a minute to become idle
-        Thread.sleep(1000 * 60);
+        Thread.sleep(1000 * 61);
         // Manually trigger the retention check because it's super flaky whether it actually gets triggered
         for (final Node node : j.jenkins.getNodes()) {
             if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == cloud) {


### PR DESCRIPTION
Release of 2.3.4 got screwed up because Jenkins forced a password reset after the Confluence monero [hack](https://www.bleepingcomputer.com/news/security/jenkins-projects-confluence-server-hacked-to-mine-monero/). In my efforts to fix it, I got rid of this commit :|