### PR TITLE
fix null weight in asg override

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -95,6 +95,7 @@ public class AutoScalingGroupFleet implements EC2Fleet {
                 .map(MixedInstancesPolicy::getLaunchTemplate)
                 .map(LaunchTemplate::getOverrides)
                 .map(overrides -> overrides.stream()
+                        .filter(o -> o.getWeightedCapacity() != null)
                         .collect(Collectors.toMap(LaunchTemplateOverrides::getInstanceType,
                                 override -> Double.parseDouble(override.getWeightedCapacity()))))
                 .orElse(Collections.emptyMap());

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -259,7 +259,6 @@ public class AutoScalingGroupFleetTest {
                                                 .withWeightedCapacity("2"),
                                         new LaunchTemplateOverrides()
                                                 .withInstanceType("t3.xlarge")
-                                                .withWeightedCapacity("4.3")
                                 )
                         )
                 )
@@ -273,7 +272,6 @@ public class AutoScalingGroupFleetTest {
         final Map<String, Double> expectedWeights = new LinkedHashMap<>();
         expectedWeights.put("t3.small", 1d);
         expectedWeights.put("t3.large", 2d);
-        expectedWeights.put("t3.xlarge", 4.3d);
 
         assertEquals(desiredCapacity, result.getNumDesired());
         assertEquals(ASG_NAME, result.getFleetId());


### PR DESCRIPTION
#295 broke asg fleets when the instance weights were not set. This filters out overrides when the weight is null and modifies the test to verify that case

Fixes #298 