### PR TITLE
Remove oldId reassignment with fleetId

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
@@ -20,4 +20,5 @@ public abstract class AbstractEC2FleetCloud extends Cloud {
 
     public abstract String getOldId();
 
+    public abstract String getFleet();
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -214,13 +214,11 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         this.cloudStatusIntervalSec = cloudStatusIntervalSec;
         this.noDelayProvision = noDelayProvision;
 
-        if (StringUtils.isNotEmpty(oldId)) {
-            id.setValue(oldId);
+        if (fleet != null) {
             this.stats = EC2Fleets.get(fleet).getState(
                     getAwsCredentialsId(), region, endpoint, getFleet());
-            // existent cloud was modified, let's re-assign all dependencies of old cloud instance
-            // to new one
-            EC2FleetCloudAwareUtils.reassign(oldId, this);
+            // Reassign existing nodes/computer with new reference of cloud
+            EC2FleetCloudAwareUtils.reassign(fleet, this);
         }
     }
 
@@ -281,6 +279,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         return maxTotalUses == null ? DEFAULT_MAX_TOTAL_USES : maxTotalUses;
     }
 
+    @Override
     public String getFleet() {
         return fleet;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -190,6 +190,12 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         return id.getValue();
     }
 
+    @Override
+    public String getFleet() {
+        // TODO: We need a way to map existing node/computer's cloud reference rather than relying on oldId
+        return null;
+    }
+
     public boolean isDisableTaskResubmit() {
         return disableTaskResubmit;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/utils/EC2FleetCloudAwareUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/utils/EC2FleetCloudAwareUtils.java
@@ -5,6 +5,7 @@ import com.amazon.jenkins.ec2fleet.EC2FleetCloudAware;
 import hudson.model.Computer;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.Nonnull;
 import java.util.logging.Logger;
@@ -17,25 +18,30 @@ public class EC2FleetCloudAwareUtils {
 
     private static final Logger LOGGER = Logger.getLogger(EC2FleetCloudAwareUtils.class.getName());
 
-    public static void reassign(final @Nonnull String oldId, @Nonnull final AbstractEC2FleetCloud cloud) {
-        for (final Computer computer : Jenkins.getActiveInstance().getComputers()) {
-            LOGGER.info("reassigning Jenkins computers");
-            checkAndReassign(oldId, cloud, computer);
-        }
+    public static void reassign(final @Nonnull String id, @Nonnull final AbstractEC2FleetCloud cloud) {
+        if (Jenkins.getActiveInstance() != null ) {
+            if (Jenkins.getActiveInstance().getComputers() != null) {
+                for (final Computer computer : Jenkins.getActiveInstance().getComputers()) {
+                    LOGGER.info("Trying to reassign Jenkins computer:" + computer.getDisplayName());
+                    checkAndReassign(id, cloud, computer);
+                }
+            }
 
-        for (final Node node : Jenkins.getActiveInstance().getNodes()) {
-            LOGGER.info("reassigning Jenkins nodes");
-            checkAndReassign(oldId, cloud, node);
+            if (Jenkins.getActiveInstance().getNodes() != null) {
+                for (final Node node : Jenkins.getActiveInstance().getNodes()) {
+                    LOGGER.info("Trying to reassign Jenkins node:" + node.getDisplayName());
+                    checkAndReassign(id, cloud, node);
+                }
+            }
         }
-
-        LOGGER.info("Finished reassigning resources from old cloud with id " + oldId + " to " + cloud.getDisplayName());
     }
 
-    private static void checkAndReassign(final String oldId, final AbstractEC2FleetCloud cloud, final Object object) {
+    private static void checkAndReassign(final String id, final AbstractEC2FleetCloud cloud, final Object object) {
         if (object instanceof EC2FleetCloudAware) {
             final EC2FleetCloudAware cloudAware = (EC2FleetCloudAware) object;
             final AbstractEC2FleetCloud oldCloud = cloudAware.getCloud();
-            if (oldCloud != null && oldId.equals(oldCloud.getOldId())) {
+            // EC2FleetLabelCloud uses `oldId` and EC2FleetCloud uses `fleet` as id to map the cloud reference
+            if (oldCloud != null && (StringUtils.equals(id, oldCloud.getOldId()) || StringUtils.equals(id, oldCloud.getFleet()))) {
                 ((EC2FleetCloudAware) object).setCloud(cloud);
                 LOGGER.info("Reassigned " + object + " from " + oldCloud.getDisplayName() + " to " + cloud.getDisplayName());
             }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudConfigurationAsCodeTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudConfigurationAsCodeTest.java
@@ -1,19 +1,38 @@
 package com.amazon.jenkins.ec2fleet;
 
+import com.amazon.jenkins.ec2fleet.fleet.EC2Fleet;
+import com.amazon.jenkins.ec2fleet.fleet.EC2Fleets;
 import hudson.plugins.sshslaves.SSHConnector;
 import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class EC2FleetCloudConfigurationAsCodeTest {
 
     @Rule
     public JenkinsRule jenkinsRule = new JenkinsConfiguredWithCodeRule();
+
+    @Before
+    public void before() {
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), nullable(String.class), anyString()))
+                .thenReturn(new FleetStateStats("", 2, FleetStateStats.State.active(), new HashSet<>(Arrays.asList("i-1", "i-2")), Collections.emptyMap()));
+    }
 
     @Test
     @ConfiguredWithCode("EC2FleetCloud/min-configuration-as-code.yml")

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -391,9 +391,9 @@ public class EC2FleetCloudTest {
         // given
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
+        // Don't set the status
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new FleetStateStats("", 0, FleetStateStats.State.active(),
-                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                .thenReturn(null);
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
@@ -414,9 +414,9 @@ public class EC2FleetCloudTest {
         // given
         when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
 
+        // Don't set the status
         PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
-                .thenReturn(new FleetStateStats("", 0, FleetStateStats.State.active(),
-                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+                .thenReturn(null);
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyIntegrationTest.java
@@ -108,14 +108,20 @@ public class EC2RetentionStrategyIntegrationTest extends IntegrationTest {
         List<QueueTaskFuture> rs = enqueTask(10, 90);
         triggerSuggestReviewNow();
 
-        final EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
+        EC2FleetCloud cloud = new EC2FleetCloud(null, "null", "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
-                1, 0, 0, 1, false, true, "-1", false, 0, 0, false, 999, false);
-        cloud.update();
+                1, 2, 2, 1, false, true, "-1", false, 0, 0, false, 999, false);
         j.jenkins.clouds.add(cloud);
+        cloud.update();
 
         assertAtLeastOneNode();
-
+        cloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
+                1, 0, 0, 1, false, true, "-1", false, 0, 0, false, 99, false);
+        j.jenkins.clouds.clear();
+        j.jenkins.clouds.add(cloud);
+        assertAtLeastOneNode();
+        cloud.update();
         final ArgumentCaptor<TerminateInstancesRequest> argument = ArgumentCaptor.forClass(TerminateInstancesRequest.class);
 
         // Nodes take a minute to become idle

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -57,6 +57,11 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerLauncher computerLauncher = mock(ComputerLauncher.class);
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                new FleetStateStats("", 0, FleetStateStats.State.active(), Collections.emptySet(),
+                        Collections.<String, Double>emptyMap()));
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
@@ -67,13 +72,6 @@ public class ProvisionIntegrationTest extends IntegrationTest {
 
         final EC2Api ec2Api = spy(EC2Api.class);
         Registry.setEc2Api(ec2Api);
-
-        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
-        EC2Fleets.setGet(ec2Fleet);
-
-        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
-                new FleetStateStats("", 0, FleetStateStats.State.active(), Collections.emptySet(),
-                        Collections.<String, Double>emptyMap()));
 
         AmazonEC2 amazonEC2 = mock(AmazonEC2.class);
         when(ec2Api.connect(anyString(), anyString(), Mockito.nullable(String.class))).thenReturn(amazonEC2);
@@ -129,16 +127,16 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerLauncher computerLauncher = mock(ComputerLauncher.class);
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
-
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                new FleetStateStats("", 0, FleetStateStats.State.active(),
+                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false,
                 "-1", false, 300, 15, false,
                 2, false));
-
-        // provide init state
-        cloud.setStats(new FleetStateStats("", 0, FleetStateStats.State.active(),
-                Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         j.jenkins.clouds.add(cloud);
 
@@ -147,6 +145,8 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         List<QueueTaskFuture> rs = enqueTask(1);
 
         final String labelString = "momo";
+        // Allow Jenkins to sync `stats` object. Removing this calls provision twice as stats remains null on first try
+        Thread.sleep(TimeUnit.SECONDS.toMillis(2));
         triggerSuggestReviewNow(labelString);
 
         Thread.sleep(TimeUnit.MINUTES.toMillis(2));
@@ -161,7 +161,11 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerLauncher computerLauncher = mock(ComputerLauncher.class);
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
-
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                new FleetStateStats("", 0, FleetStateStats.State.active(),
+                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         final EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false,
@@ -246,7 +250,11 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerLauncher computerLauncher = mock(ComputerLauncher.class);
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
-
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                new FleetStateStats("", 0, FleetStateStats.State.active(),
+                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 10, 1, true, false,
@@ -279,7 +287,11 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         ComputerLauncher computerLauncher = mock(ComputerLauncher.class);
         ComputerConnector computerConnector = mock(ComputerConnector.class);
         when(computerConnector.launch(anyString(), any(TaskListener.class))).thenReturn(computerLauncher);
-
+        final EC2Fleet ec2Fleet = mock(EC2Fleet.class);
+        EC2Fleets.setGet(ec2Fleet);
+        when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                new FleetStateStats("", 0, FleetStateStats.State.active(),
+                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
                 0, 0, 2, 1, true, false,

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -107,7 +107,7 @@ public class UiIntegrationTest {
 
     @Test
     public void shouldReplaceCloudForNodesAfterConfigurationSave() throws Exception {
-        EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
+        EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, "",
                 null, null, null, false, false,
                 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,


### PR DESCRIPTION
Remove reliance on oldId for nodes/computers reassignment instead use fleetId. More details regarding bug here: https://github.com/jenkinsci/ec2-fleet-plugin/issues/302