### PR TITLE
Add count of builds left for instances

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -45,8 +45,12 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
     public String getDisplayName() {
         if(cloud != null) {
             final String displayName = String.format("%s %s", cloud.getDisplayName(), name);
-            if (getNode() != null && getNode().getMaxTotalUses() != -1) {
-                return String.format("%s Builds left: %d ", displayName, getNode().getMaxTotalUses());
+            final EC2FleetNode node = getNode();
+            if(node != null) {
+                final int totalUses = node.getMaxTotalUses();
+                if(totalUses != -1) {
+                    return String.format("%s Builds left: %d ", displayName, getNode().getMaxTotalUses());
+                }
             }
             return displayName;
         }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -28,10 +28,7 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
 
     @Override
     public EC2FleetNode getNode() {
-        if(super.getNode() != null) {
-            return (EC2FleetNode) super.getNode();
-        }
-        return null;
+        return (EC2FleetNode) super.getNode();
     }
 
     /**

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -28,7 +28,10 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
 
     @Override
     public EC2FleetNode getNode() {
-        return (EC2FleetNode) super.getNode();
+        if(super.getNode() != null) {
+            return (EC2FleetNode) super.getNode();
+        }
+        return null;
     }
 
     /**
@@ -48,7 +51,7 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
             return displayName;
         }
         // in some multi-thread edge cases cloud could be null for some time, just be ok with that
-        return "unknown fleet";
+        return "unknown fleet" + " " + name;
     }
 
     /**

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -49,7 +49,7 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
             if(node != null) {
                 final int totalUses = node.getMaxTotalUses();
                 if(totalUses != -1) {
-                    return String.format("%s Builds left: %d ", displayName, getNode().getMaxTotalUses());
+                    return String.format("%s Builds left: %d ", displayName, totalUses);
                 }
             }
             return displayName;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -40,8 +40,15 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
     @Nonnull
     @Override
     public String getDisplayName() {
+        if(cloud != null) {
+            final String displayName = String.format("%s %s", cloud.getDisplayName(), name);
+            if (getNode() != null && getNode().getMaxTotalUses() != -1) {
+                return String.format("%s Builds left: %d ", displayName, getNode().getMaxTotalUses());
+            }
+            return displayName;
+        }
         // in some multi-thread edge cases cloud could be null for some time, just be ok with that
-        return (cloud == null ? "unknown fleet" : cloud.getDisplayName()) + " " + name;
+        return "unknown fleet";
     }
 
     /**

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategy.java
@@ -106,6 +106,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<SlaveComputer> imple
                 } else if (maxTotalUses <= 1) {
                     LOGGER.info("maxTotalUses drained - suspending agent after current build " + computer.getName());
                     computer.setAcceptingTasks(false);
+                    ec2FleetNode.setMaxTotalUses(ec2FleetNode.getMaxTotalUses() - 1);
                 } else {
                     ec2FleetNode.setMaxTotalUses(ec2FleetNode.getMaxTotalUses() - 1);
                     LOGGER.info("Agent " + computer.getName() + " has " + ec2FleetNode.getMaxTotalUses() + " builds left");


### PR DESCRIPTION
Adding count of builds left for instances as executor status. If the count of builds is set to be unlimited, then we would not be showing the counts. 
![Screen Shot 2021-11-03 at 3 51 50 PM](https://user-images.githubusercontent.com/8606563/140781055-41958775-d526-404c-91c4-619259635999.png)


