### PR TITLE
Fix save configuration to avoid resetting build counts

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -581,7 +581,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
         final Set<String> jenkinsInstances = new HashSet<>();
         for (final Node node : jenkins.getNodes()) {
-            if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud() == this) {
+            if (node instanceof EC2FleetNode && ((EC2FleetNode) node).getCloud().getFleet().equals(fleet)) {
                 jenkinsInstances.add(node.getNodeName());
             }
         }


### PR DESCRIPTION
Whenever the user modifies any configuration setting, the plugin resets the build counts back to `maxTotalBuild`. After debugging, I found that we refer to old cloud object for `CloudNanny` which triggers the plugin to re-add already existing node within Jenkins. This bug probably existed for the longest time however it never affected anything until we add `maxTotalBuild` feature. 

More details: When we run `update()`, the cloud object (`this`) continues to refer to old cloud object in it's initial run (probably because it was scheduled during/prior the configuration save process) while `EC2FleetNode` is already re-assigned with the latest cloud object. This causes us to re-add the node hence resetting the build counts. The `update()` fixes itself in subsequent run however the re-add process is already done by then. This usually happens when the cloud status interval i set low (~5 seconds). The constructor initialization takes around ~3 seconds which results in `update()` and initialization to happen around the same time. 