### PR TITLE
Force terminate instance when it exhausts maxTotalBuilds

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/AbstractEC2FleetCloud.java
@@ -16,7 +16,7 @@ public abstract class AbstractEC2FleetCloud extends Cloud {
 
     public abstract boolean hasExcessCapacity();
 
-    public abstract boolean scheduleToTerminate(String instanceId);
+    public abstract boolean scheduleToTerminate(String instanceId, boolean force);
 
     public abstract String getOldId();
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -560,7 +560,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         }
     }
 
-    public synchronized boolean scheduleToTerminate(final String instanceId) {
+    public synchronized boolean scheduleToTerminate(final String instanceId, boolean force) {
         info("Attempting to terminate instance: %s", instanceId);
 
         final Node node = Jenkins.getActiveInstance().getNode(instanceId);
@@ -572,14 +572,14 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             return false;
         }
 
-        // We can't remove instances beyond minSize
+        // We can't remove instances beyond minSize unless force is true
         final EC2FleetLabelParameters parameters = new EC2FleetLabelParameters(node.getLabelString());
         final int minSize = parameters.getIntOrDefault("minSize", this.minSize);
-        if (minSize > 0 && state.stats.getNumDesired() - state.instanceIdsToTerminate.size() <= minSize) {
+        if (!force && (minSize > 0 && state.stats.getNumDesired() - state.instanceIdsToTerminate.size() <= minSize)) {
             info("Not terminating %s because we need a minimum of %s instances running.", instanceId, minSize);
             return false;
         }
-
+        info("Scheduling instance '%s' for termination on cloud %s with force: %b", instanceId, this, force);
         state.instanceIdsToTerminate.add(instanceId);
         return true;
     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -81,7 +81,7 @@ public class EC2FleetNodeComputer extends SlaveComputer implements EC2FleetCloud
             final String instanceId = node.getNodeName();
             final AbstractEC2FleetCloud cloud = node.getCloud();
             if (cloud != null && StringUtils.isNotBlank(instanceId)) {
-                cloud.scheduleToTerminate(instanceId);
+                cloud.scheduleToTerminate(instanceId, false);
             }
         }
         return super.doDoDelete();

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategy.java
@@ -61,7 +61,7 @@ public class EC2RetentionStrategy extends RetentionStrategy<SlaveComputer> imple
                 }
 
                 final String instanceId = compNode.getNodeName();
-                if (cloud.scheduleToTerminate(instanceId)) {
+                if (cloud.scheduleToTerminate(instanceId, false)) {
                     // Instance successfully scheduled for termination, so no longer accept tasks
                     shouldAcceptTasks = false;
                     justTerminated = true;
@@ -134,7 +134,8 @@ public class EC2RetentionStrategy extends RetentionStrategy<SlaveComputer> imple
                 if (computer.countBusy() <= 1 && !computer.isAcceptingTasks()) {
                     LOGGER.info("Calling scheduleToTerminate for node " + ec2FleetNode.getNodeName() + " due to maxTotalUses (" + ec2FleetNode.getMaxTotalUses() + ")");
                     computer.setAcceptingTasks(false);
-                    cloud.scheduleToTerminate(ec2FleetNode.getNodeName());
+                    // Schedule instance for termination even if it breaches min size constraint
+                    cloud.scheduleToTerminate(ec2FleetNode.getNodeName(), true);
                 } else {
                     if (ec2FleetNode.getMaxTotalUses() == 1) {
                         LOGGER.info("Agent " + ec2FleetNode.getNodeName() + " is still in use by more than one (" + computer.countBusy() + ") executors.");

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -425,7 +425,7 @@ public class EC2FleetCloudTest {
                 10, false);
 
         // when
-        boolean r = fleetCloud.scheduleToTerminate("z");
+        boolean r = fleetCloud.scheduleToTerminate("z", false);
 
         // then
         assertFalse(r);
@@ -450,7 +450,7 @@ public class EC2FleetCloudTest {
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         // when
-        boolean r = fleetCloud.scheduleToTerminate("z");
+        boolean r = fleetCloud.scheduleToTerminate("z", false);
 
         // then
         assertFalse(r);
@@ -475,7 +475,7 @@ public class EC2FleetCloudTest {
                 Collections.singleton("z"), Collections.<String, Double>emptyMap()));
 
         // when
-        boolean r = fleetCloud.scheduleToTerminate("z");
+        boolean r = fleetCloud.scheduleToTerminate("z", false);
 
         // then
         assertFalse(r);
@@ -500,7 +500,7 @@ public class EC2FleetCloudTest {
                 new HashSet<>(Arrays.asList("z", "z1")), Collections.<String, Double>emptyMap()));
 
         // when
-        boolean r = fleetCloud.scheduleToTerminate("z");
+        boolean r = fleetCloud.scheduleToTerminate("z", false);
 
         // then
         assertTrue(r);
@@ -526,8 +526,8 @@ public class EC2FleetCloudTest {
                 new HashSet<>(Arrays.asList("z-1", "z-2")), Collections.<String, Double>emptyMap()));
 
         // when
-        boolean r1 = fleetCloud.scheduleToTerminate("z-1");
-        boolean r2 = fleetCloud.scheduleToTerminate("z-2");
+        boolean r1 = fleetCloud.scheduleToTerminate("z-1", false);
+        boolean r2 = fleetCloud.scheduleToTerminate("z-2", false);
 
         // then
         assertTrue(r1);
@@ -554,9 +554,9 @@ public class EC2FleetCloudTest {
                 new HashSet<>(Arrays.asList("z1", "z2", "z3")), Collections.<String, Double>emptyMap()));
 
         // when
-        boolean r1 = fleetCloud.scheduleToTerminate("z1");
-        boolean r2 = fleetCloud.scheduleToTerminate("z2");
-        boolean r3 = fleetCloud.scheduleToTerminate("z3");
+        boolean r1 = fleetCloud.scheduleToTerminate("z1", false);
+        boolean r2 = fleetCloud.scheduleToTerminate("z2", false);
+        boolean r3 = fleetCloud.scheduleToTerminate("z3", false);
 
         // then
         assertTrue(r1);
@@ -635,7 +635,7 @@ public class EC2FleetCloudTest {
         fleetCloud.setStats(currentState);
 
         fleetCloud.provision(null, 2);
-        fleetCloud.scheduleToTerminate("i-1");
+        fleetCloud.scheduleToTerminate("i-1", false);
 
         // when
         fleetCloud.update();
@@ -665,7 +665,7 @@ public class EC2FleetCloudTest {
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         for (int i = 0; i < 10; i++) fleetCloud.provision(null, 1);
-        for (int i = 0; i < 10; i++) fleetCloud.scheduleToTerminate("i-" + i);
+        for (int i = 0; i < 10; i++) fleetCloud.scheduleToTerminate("i-" + i, false);
         for (int i = 0; i < 10; i++) fleetCloud.provision(null, 1);
 
         // when
@@ -696,7 +696,7 @@ public class EC2FleetCloudTest {
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
         for (int i = 0; i < 10; i++) fleetCloud.provision(null, 1);
-        for (int i = 0; i < 5; i++) fleetCloud.scheduleToTerminate("i-" + i);
+        for (int i = 0; i < 5; i++) fleetCloud.scheduleToTerminate("i-" + i, false);
 
         // when
         fleetCloud.update();
@@ -725,8 +725,8 @@ public class EC2FleetCloudTest {
         fleetCloud.setStats(new FleetStateStats("", 4, FleetStateStats.State.active(),
                 Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
 
-        fleetCloud.scheduleToTerminate("i-1");
-        fleetCloud.scheduleToTerminate("i-2");
+        fleetCloud.scheduleToTerminate("i-1", false);
+        fleetCloud.scheduleToTerminate("i-2", false);
 
         // when
         fleetCloud.update();
@@ -1001,8 +1001,8 @@ public class EC2FleetCloudTest {
 
         doNothing().when(jenkins).addNode(any(Node.class));
 
-        fleetCloud.scheduleToTerminate("i-0");
-        fleetCloud.scheduleToTerminate("i-1");
+        fleetCloud.scheduleToTerminate("i-0", false);
+        fleetCloud.scheduleToTerminate("i-1", false);
 
         // when
         fleetCloud.update();
@@ -1184,7 +1184,7 @@ public class EC2FleetCloudTest {
 
         doNothing().when(jenkins).addNode(any(Node.class));
 
-        fleetCloud.scheduleToTerminate("i-0");
+        fleetCloud.scheduleToTerminate("i-0", false);
 
         // when
         fleetCloud.update();

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
@@ -42,9 +42,9 @@ public class EC2FleetCloudWithMeter extends EC2FleetCloud {
     }
 
     @Override
-    public boolean scheduleToTerminate(final String instanceId) {
+    public boolean scheduleToTerminate(final String instanceId, boolean force) {
         try (Meter.Shot s = removeMeter.start()) {
-            return super.scheduleToTerminate(instanceId);
+            return super.scheduleToTerminate(instanceId, force);
         }
     }
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2MaxTotalUsesRetentionStrategyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2MaxTotalUsesRetentionStrategyTest.java
@@ -39,12 +39,12 @@ public class EC2MaxTotalUsesRetentionStrategyTest {
                 rs.taskCompleted(executor, null, 0);
             }
             if (usageCount == 1) {
-                verify(cloud, times(1)).scheduleToTerminate("name");
+                verify(cloud, times(1)).scheduleToTerminate("name", true);
             } else if (usageCount == 0) {
                 // We would have called terminate twice: 0 & 1
-                verify(cloud, times(2)).scheduleToTerminate("name");
+                verify(cloud, times(2)).scheduleToTerminate("name", true);
             } else {
-                verify(cloud, times(0)).scheduleToTerminate("name");
+                verify(cloud, times(0)).scheduleToTerminate("name", true);
             }
             usageCount--;
         }
@@ -68,6 +68,6 @@ public class EC2MaxTotalUsesRetentionStrategyTest {
         if (!computer.isAcceptingTasks()) {
             rs.taskCompleted(executor, null, 0);
         }
-        verify(cloud, times(0)).scheduleToTerminate("name");
+        verify(cloud, times(0)).scheduleToTerminate("name", true);
     }
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2RetentionStrategyTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -50,7 +51,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, times(0)).getNode();
-        verify(cloud, times(0)).scheduleToTerminate(anyString());
+        verify(cloud, times(0)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(false);
         verify(slaveComputer).setAcceptingTasks(true);
     }
@@ -63,7 +64,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, times(1)).getNode();
-        verify(cloud, times(1)).scheduleToTerminate(anyString());
+        verify(cloud, times(1)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(false);
     }
 
@@ -75,7 +76,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, times(0)).getNode();
-        verify(cloud, times(0)).scheduleToTerminate(anyString());
+        verify(cloud, times(0)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(true);
     }
 
@@ -88,7 +89,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, times(0)).getNode();
-        verify(cloud, times(0)).scheduleToTerminate(anyString());
+        verify(cloud, times(0)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(true);
     }
 
@@ -99,7 +100,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, never()).getNode();
-        verify(cloud, never()).scheduleToTerminate(anyString());
+        verify(cloud, never()).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(false);
         verify(slaveComputer).setAcceptingTasks(true);
     }
@@ -111,7 +112,7 @@ public class EC2RetentionStrategyTest {
         new EC2RetentionStrategy().check(slaveComputer);
 
         verify(slaveComputer, times(0)).getNode();
-        verify(cloud, times(0)).scheduleToTerminate(anyString());
+        verify(cloud, times(0)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer).setAcceptingTasks(false);
         verify(slaveComputer).setAcceptingTasks(true);
     }
@@ -120,7 +121,7 @@ public class EC2RetentionStrategyTest {
     public void if_idle_time_configured_should_terminate_node_if_idle_time_more_then_allowed() {
         new EC2RetentionStrategy().check(slaveComputer);
 
-        verify(cloud, times(1)).scheduleToTerminate("n-a");
+        verify(cloud, times(1)).scheduleToTerminate("n-a", false);
         verify(slaveComputer, times(1)).setAcceptingTasks(true);
         verify(slaveComputer, times(1)).setAcceptingTasks(false);
     }
@@ -131,7 +132,7 @@ public class EC2RetentionStrategyTest {
 
         new EC2RetentionStrategy().check(slaveComputer);
 
-        verify(cloud, times(0)).scheduleToTerminate(anyString());
+        verify(cloud, times(0)).scheduleToTerminate(anyString(), anyBoolean());
         verify(slaveComputer, times(0)).setAcceptingTasks(true);
         verify(slaveComputer, times(0)).setAcceptingTasks(false);
     }
@@ -143,7 +144,7 @@ public class EC2RetentionStrategyTest {
 
         new EC2RetentionStrategy().check(slaveComputer);
 
-        verify(cloud, never()).scheduleToTerminate("n-a");
+        verify(cloud, never()).scheduleToTerminate("n-a", false);
         verify(slaveComputer, times(1)).setAcceptingTasks(true);
         verify(slaveComputer, times(1)).setAcceptingTasks(false);
     }
@@ -154,21 +155,21 @@ public class EC2RetentionStrategyTest {
 
         new EC2RetentionStrategy().check(slaveComputer);
 
-        verify(cloud, never()).scheduleToTerminate("n-a");
+        verify(cloud, never()).scheduleToTerminate("n-a", false);
         verify(slaveComputer, times(1)).setAcceptingTasks(true);
         verify(slaveComputer, times(1)).setAcceptingTasks(false);
     }
 
     @Test
     public void if_exception_happen_during_termination_should_throw_it_and_restore_task_accepting() {
-        when(cloud.scheduleToTerminate(anyString())).thenThrow(new IllegalArgumentException("test"));
+        when(cloud.scheduleToTerminate(anyString(), anyBoolean())).thenThrow(new IllegalArgumentException("test"));
 
         try {
             new EC2RetentionStrategy().check(slaveComputer);
             fail();
         } catch (IllegalArgumentException e) {
             assertEquals("test", e.getMessage());
-            verify(cloud, times(1)).scheduleToTerminate("n-a");
+            verify(cloud, times(1)).scheduleToTerminate("n-a", false);
             verify(slaveComputer).setAcceptingTasks(false);
             verify(slaveComputer).setAcceptingTasks(true);
         }


### PR DESCRIPTION
Currently, we do not terminate instance even current capacity goes below min size even if it exhausts maxTotalBuilds. The instance remains in suspended state without taking any new build/jobs. We would now forcefully terminate the instance regardless of the minSize. A new instance would be launched in the next run to satisfy minSize criteria.
