### PR TITLE
Add minimum spare instances feature

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -682,8 +682,8 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
     /**
      * Schedules Jenkins Node and EC2 instance for termination.
-     * If <code>force</code> is false, check if target capacity more than <code>minSize</code> or less than <code>minSpareSize</code> otherwise reject termination.
-     * Else if <code>force</code> is true, schedule instance for termination even if it breaches <code>minSize</code>
+     * If <code>force</code> is false and target capacity falls below <code>minSize</code> OR <code>minSpareSize</code> thresholds, then reject termination.
+     * Else if <code>force</code> is true, schedule instance for termination even if it breaches <code>minSize</code> OR <code>minSpareSize</code>
      * <p>
      * Real termination will happens in {@link EC2FleetCloud#update()} which is periodically called by
      * {@link CloudNanny}. So there could be some lag between the decision to terminate the node

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -120,6 +120,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     private final Integer idleMinutes;
     private final int minSize;
     private final int maxSize;
+    private final int minSpareSize;
     private final int numExecutors;
     private final boolean addNodeOnlyIfRunning;
     private final boolean restrictUsage;
@@ -175,6 +176,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                          final Integer idleMinutes,
                          final int minSize,
                          final int maxSize,
+                         final int minSpareSize,
                          final int numExecutors,
                          final boolean addNodeOnlyIfRunning,
                          final boolean restrictUsage,
@@ -203,6 +205,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
         this.minSize = Math.max(0, minSize);
         this.maxSize = maxSize;
+        this.minSpareSize = Math.max(0, minSpareSize);
         this.maxTotalUses = StringUtils.isBlank(maxTotalUses) ? -1 : Integer.parseInt(maxTotalUses);
         this.numExecutors = Math.max(numExecutors, 1);
         this.addNodeOnlyIfRunning = addNodeOnlyIfRunning;
@@ -318,6 +321,10 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
     public int getMinSize() {
         return minSize;
+    }
+
+    public int getMinSpareSize() {
+        return minSpareSize;
     }
 
     public int getNumExecutors() {
@@ -474,6 +481,15 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final int currentToAdd;
         final Set<String> currentInstanceIdsToTerminate;
         synchronized (this) {
+            if(minSpareSize > 0) {
+                // Check spare instances by considering FleetStateStats#getNumDesired so we account for newer instances which are in progress
+                final int currentSpareInstanceCount = getCurrentSpareInstanceCount(currentState, currentState.getNumDesired());
+                final int additionalSpareInstancesRequired = minSpareSize - currentSpareInstanceCount;
+                fine("currentSpareInstanceCount: %s additionalSpareInstancesRequired: %s", currentSpareInstanceCount, additionalSpareInstancesRequired);
+                if (additionalSpareInstancesRequired > 0) {
+                    toAdd = toAdd + additionalSpareInstancesRequired;
+                }
+            }
             currentToAdd = toAdd;
             currentInstanceIdsToTerminate = new HashSet<>(instanceIdsToTerminate);
         }
@@ -530,7 +546,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
         // Ensure target capacity is not negative (covers capacity updates from outside the plugin)
         final int targetCapacity = Math.max(minSize,
-                currentState.getNumDesired() - currentInstanceIdsToTerminate.size() + currentToAdd);
+                Math.min(maxSize, currentState.getNumDesired() - currentInstanceIdsToTerminate.size() + currentToAdd));
 
         // Modify target capacity when an instance is removed or added, even if the value of target capacity doesn't change.
         // For example, if we remove an instance and add an instance the net change is 0, but we still make the API call.
@@ -666,7 +682,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
     /**
      * Schedules Jenkins Node and EC2 instance for termination.
-     * If <code>force</code> is false, check if target capacity more than <code>minSize</code> otherwise reject termination.
+     * If <code>force</code> is false, check if target capacity more than <code>minSize</code> or less than <code>minSpareSize</code> otherwise reject termination.
      * Else if <code>force</code> is true, schedule instance for termination even if it breaches <code>minSize</code>
      * <p>
      * Real termination will happens in {@link EC2FleetCloud#update()} which is periodically called by
@@ -686,13 +702,22 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             info("First update not done, skipping termination scheduling for '%s'", instanceId);
             return false;
         }
-        // We can't remove instances beyond minSize unless force true
-        if (!force && (minSize > 0 && stats.getNumActive() - instanceIdsToTerminate.size() <= minSize)) {
-            info("Not scheduling instance '%s' for termination because we need a minimum of %s instance(s) running", instanceId, minSize);
-            fine("cloud: %s, instanceIdsToTerminate: %s", this, instanceIdsToTerminate);
-            return false;
+        // We can't remove instances beyond minSize or minSpareSize unless force true
+        if(!force) {
+            if (minSize > 0 && stats.getNumActive() - instanceIdsToTerminate.size() <= minSize) {
+                info("Not scheduling instance '%s' for termination because we need a minimum of %s instance(s) running", instanceId, minSize);
+                fine("cloud: %s, instanceIdsToTerminate: %s", this, instanceIdsToTerminate);
+                return false;
+            }
+            if (minSpareSize > 0) {
+                // Check spare instances by considering FleetStateStats#getNumActive as we want to consider only running instances
+                final int currentSpareInstanceCount = getCurrentSpareInstanceCount(stats, stats.getNumActive());
+                if (currentSpareInstanceCount - instanceIdsToTerminate.size() <= minSpareSize) {
+                    info("Not scheduling instance '%s' for termination because we need a minimum of %s spare instance(s) running", instanceId, minSpareSize);
+                    return false;
+                }
+            }
         }
-
         info("Scheduling instance '%s' for termination on cloud %s with force: %b", instanceId, this, force);
         instanceIdsToTerminate.add(instanceId);
         fine("InstanceIdsToTerminate: %s", instanceIdsToTerminate);
@@ -814,6 +839,25 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         EC2FleetOnlineChecker.start(node, future,
                 TimeUnit.SECONDS.toMillis(getInitOnlineTimeoutSec()),
                 TimeUnit.SECONDS.toMillis(getInitOnlineCheckIntervalSec()));
+    }
+
+    private int getCurrentSpareInstanceCount(final FleetStateStats currentState, final int countOfInstances) {
+        final int currentSpareInstanceCount = 0;
+        if(minSpareSize > 0) {
+            final Jenkins jenkins = Jenkins.get();
+            int currentBusyInstances = 0;
+            for (final Computer computer : jenkins.getComputers()) {
+                if (computer instanceof EC2FleetNodeComputer && !computer.isIdle()) {
+                    final Node compNode = computer.getNode();
+                    if (compNode == null) {
+                        continue;
+                    }
+                    currentBusyInstances++;
+                }
+            }
+            return countOfInstances - currentBusyInstances;
+        }
+        return 0;
     }
 
     private String getLogPrefix() {

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -92,6 +92,10 @@
       <f:number clazz="required positive-number" default="1" />
     </f:entry>
 
+    <f:entry title="${%Minimum Spare Size}" field="minSpareSize">
+        <f:number clazz="required number" min="0" default="0" />
+    </f:entry>
+
     <f:entry title="${%Maximum Total Uses}" field="maxTotalUses">
         <!-- use `textbox` here as `number` defaults to 0 when left blank.
         Zero as maxTotalUses would indicate that the builds wouldn't be scheduled at all -->

--- a/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/AutoResubmitIntegrationTest.java
@@ -74,7 +74,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
     public void should_successfully_resubmit_freestyle_task() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
-                0, 0, 10, 1, false, true,
+                0, 0, 10, 0, 1, false, true,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -110,7 +110,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
     public void should_successfully_resubmit_parametrized_task() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
-                0, 0, 10, 1, false, true,
+                0, 0, 10, 0, 1, false, true,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -166,7 +166,7 @@ public class AutoResubmitIntegrationTest extends IntegrationTest {
     public void should_not_resubmit_if_disabled() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, new LocalComputerConnector(j), false, false,
-                0, 0, 10, 1, false, true,
+                0, 0, 10, 0, 1, false, true,
                 "-1", true, 0, 0, false, 10, false);
         j.jenkins.clouds.add(cloud);
 

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -17,6 +17,7 @@ import com.amazonaws.services.ec2.model.Region;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfig;
 import com.amazonaws.services.ec2.model.SpotFleetRequestConfigData;
 import hudson.ExtensionList;
+import hudson.model.Computer;
 import hudson.model.Label;
 import hudson.model.LabelFinder;
 import hudson.model.Node;
@@ -148,7 +149,7 @@ public class EC2FleetCloudTest {
     public void canProvision_fleetIsNull(){
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", null, "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -161,7 +162,7 @@ public class EC2FleetCloudTest {
     public void canProvision_restrictUsageLabelIsNull(){
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 true, "-1", false, 0, 0, false,
                 10, false);
 
@@ -174,7 +175,7 @@ public class EC2FleetCloudTest {
     public void canProvision_LabelNotInLabelString(){
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -187,7 +188,7 @@ public class EC2FleetCloudTest {
     public void canProvision_LabelInLabelString(){
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "label1 momo", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -211,7 +212,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -237,7 +238,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 8, 3, true,
+                false, 0, 1, 8, 0, 3, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -263,7 +264,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 8, 3, true,
+                false, 0, 1, 8, 0, 3, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -289,7 +290,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 9, 1, true,
+                false, 0, 0, 9, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -315,7 +316,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -341,7 +342,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -367,7 +368,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -397,7 +398,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 1, 1, true,
+                false, 0, 0, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -420,7 +421,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 1, 1, true,
+                false, 0, 0, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -442,7 +443,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 1, 1, true,
+                false, 0, 1, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -467,7 +468,33 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 1, 1, true,
+                false, 0, 1, 1, 0, 1, true,
+                false, "-1", false, 0, 0, false,
+                10, false);
+
+        fleetCloud.setStats(new FleetStateStats("", 1, FleetStateStats.State.active(),
+                Collections.singleton("z"), Collections.<String, Double>emptyMap()));
+
+        // when
+        boolean r = fleetCloud.scheduleToTerminate("z", false);
+
+        // then
+        assertFalse(r);
+    }
+
+    @Test
+    public void scheduleToTerminate_notRemoveIfEqualMinSpare() {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("", 0, FleetStateStats.State.active(),
+                        Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
+        when(jenkins.getComputers()).thenReturn(new Computer[0]);
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "", "", null, null, false,
+                false, 0, 0, 5, 1, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -492,7 +519,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 1, 1, true,
+                false, 0, 1, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -518,7 +545,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 1, 1, true,
+                false, 0, 0, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -546,7 +573,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 1, 1, 1, true,
+                false, 0, 1, 1, 0, 1, true,
                 false, "-1", false, 0, 0, false,
                 10, false);
 
@@ -576,7 +603,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 1, 1, true,
+                false, 0, 0, 1, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -600,7 +627,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -628,7 +655,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -657,7 +684,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -688,7 +715,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -718,7 +745,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0, 1, true,
                 false, "-1", false, 0,
                 0, false, 10, false);
 
@@ -759,7 +786,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 false, "-1", false,
                 0, 0, false, 10, false);
 
@@ -801,7 +828,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 2, 1, false,
+                false, 0, 0, 2, 0, 1, false,
                 false, "-1", false,
                 0, 0, false, 10, false);
 
@@ -837,7 +864,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud("my-fleet", null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 false, "-1", false,
                 0, 0, false, 10, false);
 
@@ -878,7 +905,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 false, "-1", false,
                 0, 0, false, 10, false);
 
@@ -916,7 +943,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
 
@@ -961,7 +988,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
 
@@ -994,7 +1021,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 10, 1, false,
+                false, 0, 0, 10, 0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
         fleetCloud.setStats(initState);
@@ -1031,7 +1058,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 10, 1, false,
+                false, 0, 0, 10, 0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
         fleetCloud.setStats(initState);
@@ -1079,7 +1106,7 @@ public class EC2FleetCloudTest {
 
         final EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 10, 1, false,
+                false, 0, 0, 10, 0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
         fleetCloud.setStats(initState);
@@ -1131,7 +1158,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 10, 1, false,
+                false, 0, 0, 10, 0,1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
         fleetCloud.setStats(initState);
@@ -1177,7 +1204,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 10, 1, false,
+                false, 0, 0, 10,0, 1, false,
                 true, "-1", false,
                 0, 0, false, 10, false);
         fleetCloud.setStats(initState);
@@ -1191,6 +1218,40 @@ public class EC2FleetCloudTest {
 
         // then
         Assert.assertEquals(4, fleetCloud.getStats().getNumDesired());
+    }
+
+    @Test
+    public void update_shouldUpdateStateWithMinSpare() throws IOException {
+        // given
+        final int minSpareSize = 2;
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+
+        final HashMap<String, Instance> instanceIdMap = new HashMap<>();
+
+        when(ec2Api.describeInstances(any(AmazonEC2.class), any(Set.class))).thenReturn(
+                instanceIdMap);
+        when(jenkins.getComputers()).thenReturn(new Computer[0]);
+
+        final FleetStateStats initState = new FleetStateStats("fleetId", 0,
+                FleetStateStats.State.active(),
+                Collections.emptySet(), Collections.<String, Double>emptyMap());
+        PowerMockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(initState);
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
+                "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 10, minSpareSize, 1, false,
+                true, "-1", false,
+                0, 0, false, 10, false);
+        fleetCloud.setStats(initState);
+
+        doNothing().when(jenkins).addNode(any(Node.class));
+
+        // when
+        fleetCloud.update();
+
+        // then
+        Assert.assertEquals(minSpareSize, fleetCloud.getStats().getNumDesired());
     }
 
     @Test
@@ -1220,7 +1281,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1262,7 +1323,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1304,7 +1365,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1346,7 +1407,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1389,7 +1450,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
         // set init state so we can do provision
@@ -1434,7 +1495,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1482,7 +1543,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
         fleetCloud.setStats(initialState);
@@ -1512,7 +1573,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0,1, true,
                 false, "-1", false, timeout, 0, false,
                 1, false);
 
@@ -1543,7 +1604,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "", "", null, null, false,
-                false, 0, 0, 10, 1, true,
+                false, 0, 0, 10, 0,1, true,
                 false, "-1", false, timeout, 0, false,
                 10, false);
 
@@ -1570,7 +1631,7 @@ public class EC2FleetCloudTest {
 
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 1, 1, 1, false,
+                false, 0, 1, 1, 0,1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1586,7 +1647,7 @@ public class EC2FleetCloudTest {
         // given
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1607,7 +1668,7 @@ public class EC2FleetCloudTest {
         // given
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1626,7 +1687,7 @@ public class EC2FleetCloudTest {
         // given
         EC2FleetCloud fleetCloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 "", "fleetId", "", null, PowerMockito.mock(ComputerConnector.class), false,
-                false, 0, 0, 1, 1, false,
+                false, 0, 0, 1, 0, 1, false,
                 true, "-1", false,
                 0, 0, true, 10, false);
 
@@ -1808,7 +1869,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 null, null, null, null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false, 10, false);
         assertEquals(ec2FleetCloud.getDisplayName(), EC2FleetCloud.FLEET_CLOUD_ID);
@@ -1819,7 +1880,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 "CloudName", null, null, null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false,
                 10, false);
@@ -1831,7 +1892,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 null, null, null, null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false,
                 0, 0, false,
                 10, false);
@@ -1843,7 +1904,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 null, null, null, "Opa", null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false,
                 10, false);
@@ -1855,7 +1916,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 null, null, "Opa", null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false,
                 10, false);
@@ -1867,7 +1928,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 null, null, "A", "B", null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false,
                 10, false);
@@ -1881,7 +1942,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 "CloudName", null, null, null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 1, true, false, "-1", false
                 , 0, 0, false,
                 45, false);
@@ -1893,7 +1954,7 @@ public class EC2FleetCloudTest {
         EC2FleetCloud ec2FleetCloud = new EC2FleetCloud(
                 "CloudName", null, null, null, null, null, null,
                 null, null, null, false,
-                false, null, 0, 1,
+                false, null, 0, 1, 0,
                 0, true, false, "-1", false
                 , 0, 0, false,
                 45, false);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithHistory.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithHistory.java
@@ -15,12 +15,12 @@ public class EC2FleetCloudWithHistory extends EC2FleetCloud {
     public EC2FleetCloudWithHistory(
             String name, String oldId, String awsCredentialsId, String credentialsId, String region,
             String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector,
-            boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize,
+            boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize, Integer minSpareSize,
             Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit,
             Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight,
             Integer cloudStatusIntervalSec, boolean immediatelyProvision) {
         super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot,
-                computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors,
+                computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, minSpareSize, numExecutors,
                 addNodeOnlyIfRunning, restrictUsage, "-1", disableTaskResubmit, initOnlineTimeoutSec,
                 initOnlineCheckIntervalSec, scaleExecutorsByWeight, cloudStatusIntervalSec, immediatelyProvision);
     }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudWithMeter.java
@@ -17,11 +17,11 @@ public class EC2FleetCloudWithMeter extends EC2FleetCloud {
             String name, String oldId, String awsCredentialsId, String credentialsId, String region,
             String endpoint, String fleet, String labelString, String fsRoot, ComputerConnector computerConnector,
             boolean privateIpUsed, boolean alwaysReconnect, Integer idleMinutes, Integer minSize, Integer maxSize,
-            Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit,
+            Integer minSpareSize, Integer numExecutors, boolean addNodeOnlyIfRunning, boolean restrictUsage, boolean disableTaskResubmit,
             Integer initOnlineTimeoutSec, Integer initOnlineCheckIntervalSec, boolean scaleExecutorsByWeight,
             Integer cloudStatusIntervalSec, boolean immediatelyProvision) {
         super(name, oldId, awsCredentialsId, credentialsId, region, endpoint, fleet, labelString, fsRoot,
-                computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, numExecutors,
+                computerConnector, privateIpUsed, alwaysReconnect, idleMinutes, minSize, maxSize, minSpareSize, numExecutors,
                 addNodeOnlyIfRunning, restrictUsage, "-1", disableTaskResubmit, initOnlineTimeoutSec, initOnlineCheckIntervalSec,
                 scaleExecutorsByWeight, cloudStatusIntervalSec, immediatelyProvision);
     }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyPerformanceTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategyPerformanceTest.java
@@ -55,7 +55,7 @@ public class NoDelayProvisionStrategyPerformanceTest extends IntegrationTest {
         final String label = "momo";
         final EC2FleetCloudWithHistory cloud = new EC2FleetCloudWithHistory(null, null, "credId", null, "region",
                 null, "fId", label, null, computerConnector, false, false,
-                1, 0, maxWorkers, 1, true, false,
+                1, 0, maxWorkers, 0, 1, true, false,
                 false, 0, 0, false,
                 15, noDelay);
         j.jenkins.clouds.add(cloud);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionIntegrationTest.java
@@ -65,7 +65,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 0, 1, true, false,
+                0, 0, 0, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 2, false);
         j.jenkins.clouds.add(cloud);
@@ -99,7 +99,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
 
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false,
+                0, 0, 10, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 2, false);
         j.jenkins.clouds.add(cloud);
@@ -134,7 +134,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false,
+                0, 0, 10, 0, 1, true, false,
                 "-1", false, 300, 15, false,
                 2, false));
 
@@ -168,7 +168,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         final EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false,
+                0, 0, 10, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 10, false));
         j.jenkins.clouds.add(cloud);
@@ -196,7 +196,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
 
         EC2FleetCloud cloud = spy(new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false,
+                0, 0, 10, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 10, false));
 
@@ -257,7 +257,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 10, 1, true, false,
+                0, 0, 10, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 2, false);
         j.jenkins.clouds.add(cloud);
@@ -294,7 +294,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
                         Collections.<String>emptySet(), Collections.<String, Double>emptyMap()));
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                0, 0, 2, 1, true, false,
+                0, 0, 2, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 2, false);
         j.jenkins.clouds.add(cloud);
@@ -325,7 +325,7 @@ public class ProvisionIntegrationTest extends IntegrationTest {
         final ComputerConnector computerConnector = new LocalComputerConnector(j);
         final EC2FleetCloud cloud = new EC2FleetCloud(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                1, 0, 5, 1, true, false,
+                1, 0, 5, 0, 1, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/ProvisionPerformanceTest.java
@@ -41,7 +41,7 @@ public class ProvisionPerformanceTest extends IntegrationTest {
         final ComputerConnector computerConnector = new LocalComputerConnector(j);
         final EC2FleetCloudWithMeter cloud = new EC2FleetCloudWithMeter(null, null, "credId", null, "region",
                 null, "fId", "momo", null, computerConnector, false, false,
-                1, 0, workers, 1, true, false,
+                1, 0, workers, 0, 1, true, false,
                 false, 0, 0, false,
                 2, false);
         j.jenkins.clouds.add(cloud);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/RealTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/RealTest.java
@@ -133,7 +133,7 @@ public class RealTest extends IntegrationTest {
                 "", null, credentialId, null, null, null,
                 autoScalingGroupName,
                 "momo", null, computerConnector, false, false,
-                1, 0, 5, 1, true, false,
+                1, 0, 5, 0, 1, true, false,
                 "-1", false, 180, 15, false,
                 10, true);
         j.jenkins.clouds.add(cloud);
@@ -185,7 +185,7 @@ public class RealTest extends IntegrationTest {
                 "", null, credentialId, null, null, null,
                 requestSpotFleetResult.getSpotFleetRequestId(),
                 "momo", null, computerConnector, false, false,
-                1, 0, 5, 1, true, false,
+                1, 0, 5, 0, 1, true, false,
                 "-1", false, 180, 15, false,
                 10, true);
         j.jenkins.clouds.add(cloud);

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -43,16 +43,14 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
- * Detailed guides https://jenkins.io/doc/developer/testing/
- * https://wiki.jenkins.io/display/JENKINS/Unit+Test#UnitTest-DealingwithproblemsinJavaScript
+ * Detailed guides https://jenkins.io/doc/developer/testing/ https://wiki.jenkins.io/display/JENKINS/Unit+Test#UnitTest-DealingwithproblemsinJavaScript
  */
 public class UiIntegrationTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
-
     @ClassRule
     public static BuildWatcher bw = new BuildWatcher();
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     @Before
     public void before() {
@@ -77,7 +75,7 @@ public class UiIntegrationTest {
     public void shouldShowAsHiddenCloudIdAsOldId() throws IOException, SAXException {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -91,7 +89,7 @@ public class UiIntegrationTest {
     public void shouldShowNodeConfigurationPage() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -109,7 +107,7 @@ public class UiIntegrationTest {
     public void shouldReplaceCloudForNodesAfterConfigurationSave() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud(null, null, null, null, null, null, "",
                 null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -135,7 +133,7 @@ public class UiIntegrationTest {
     public void shouldShowInConfigurationClouds() throws IOException, SAXException {
         Cloud cloud = new EC2FleetCloud(null, null, null, null, null, null, null,
                 null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud);
@@ -149,14 +147,14 @@ public class UiIntegrationTest {
     public void shouldShowMultipleClouds() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud2);
@@ -173,14 +171,14 @@ public class UiIntegrationTest {
     public void shouldShowMultipleCloudsWithDefaultName() throws IOException, SAXException {
         Cloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
 
         Cloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud2);
@@ -197,14 +195,14 @@ public class UiIntegrationTest {
     public void shouldUpdateProperCloudWhenMultiple() throws IOException, SAXException {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud2);
@@ -224,7 +222,7 @@ public class UiIntegrationTest {
     public void shouldContainRegionValueInRegionLabel() throws IOException, SAXException {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, "uh", null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
@@ -246,7 +244,7 @@ public class UiIntegrationTest {
         final String displayName = "us-east-1 US East (N. Virginia)";
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, "uh", null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
@@ -259,7 +257,7 @@ public class UiIntegrationTest {
         for (final DomElement regionElement : regionDropDown.get(0).getChildElements()) {
             final String label = regionElement.getAttributes().getNamedItem("label").getTextContent();
             final String value = regionElement.getAttributes().getNamedItem("value").getTextContent();
-            if(StringUtils.equals(value, regionName)) {
+            if (StringUtils.equals(value, regionName)) {
                 isPresent = true;
                 assertEquals(displayName, label);
             }
@@ -273,14 +271,14 @@ public class UiIntegrationTest {
     public void shouldGetFirstWhenMultipleCloudWithSameName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud(null, null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud2);
@@ -292,14 +290,14 @@ public class UiIntegrationTest {
     public void shouldGetProperWhenMultipleWithDiffName() {
         EC2FleetCloud cloud1 = new EC2FleetCloud("a", null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud1);
 
         EC2FleetCloud cloud2 = new EC2FleetCloud("b", null, null, null, null, null,
                 null, null, null, null, false, false,
-                0, 0, 0, 0, true, false,
+                0, 0, 0, 0, 0, true, false,
                 "-1", false, 0, 0, false,
                 10, false);
         j.jenkins.clouds.add(cloud2);


### PR DESCRIPTION
Add minimum spare instances feature to allow faster builds. `Minimum spare size` are the count of instances that will be idle to pick up any upcoming build immediately. Once the build is picked up, we would then replenish `minimum spare size` by launching newer instances. Max cluster size would be respected if adding minimum spare instance size would breach max cluster size. By default, minimum spare instance size is 0. The minimum spare instances do not get terminated if they remain idle for max allow idle time. 
