### PR TITLE
Fix missing params for resubmitted jobs in pipelines

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,11 @@
       <artifactId>credentials</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>aws-java-sdk</artifactId>
       <version>${aws-sdk.version}</version>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding workflow job plugin dependency to gather parameters. This should work as a temporary fix for now. Long term we can built something like the rebuild plugin which has a UI to save the existing parameters. Tested the changes manually while having multiple builds on single instance and terminating the instance abruptly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
