### PR TITLE
Fix getCurrentSpareInstanceCount - check busy nodes in given fleet, not whole Jenkins instance

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -30,7 +30,16 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -30,16 +30,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -850,6 +841,9 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 if (computer instanceof EC2FleetNodeComputer && !computer.isIdle()) {
                     final Node compNode = computer.getNode();
                     if (compNode == null) {
+                        continue;
+                    }
+                    if (!Objects.equals(((EC2FleetNodeComputer) computer).getCloud().getFleet(), currentState.getFleetId())) {
                         continue;
                     }
                     currentBusyInstances++;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -468,7 +468,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         fine("start cloud %s", this);
 
         // Make a snapshot of current cloud state to work with.
-        // We should always work with the snapshot since data could be modified in another thread
+        // We should always work with ]the snapshot since data could be modified in another thread
         FleetStateStats currentState = EC2Fleets.get(fleet).getState(
                 getAwsCredentialsId(), region, endpoint, getFleet());
 
@@ -853,6 +853,8 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                     if (compNode == null) {
                         continue;
                     }
+
+                    // Do not count computer if it is not a part of the given fleet
                     if (!Objects.equals(((EC2FleetNodeComputer) computer).getCloud().getFleet(), currentState.getFleetId())) {
                         continue;
                     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -468,7 +468,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         fine("start cloud %s", this);
 
         // Make a snapshot of current cloud state to work with.
-        // We should always work with ]the snapshot since data could be modified in another thread
+        // We should always work with the snapshot since data could be modified in another thread
         FleetStateStats currentState = EC2Fleets.get(fleet).getState(
                 getAwsCredentialsId(), region, endpoint, getFleet());
 


### PR DESCRIPTION
This fixes #342.
getCurrentSpareInstanceCount checks in whole Jenkins computers and does not account that we want to check only in given fleet. 
I added a filter to filter worker nodes only from given fleet that is being checked. If we are not checking the computer from given fleet - we continue, we don't want to count the computer as busy computer in given fleet, **because it is not a part of given fleet**.