### PR TITLE
Fix typo in jcasc configuration example

### DIFF
--- a/docs/CONFIGURATION-AS-CODE.md
+++ b/docs/CONFIGURATION-AS-CODE.md
@@ -49,7 +49,7 @@ jenkins:
     - ec2Fleet:
         name: ec2-fleet
         computerConnector:
-            ssh:
+            sshConnector:
                 credentialsId: cred
                 sshHostKeyVerificationStrategy:
                   NonVerifyingKeyVerificationStrategy


### PR DESCRIPTION
Just fix typo in `jcasc` minimal configuration example. It may save some time for consumers of the plugin.

```java
2022-11-24 20:30:34.371+0000 [id=29]    SEVERE  jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
java.lang.IllegalArgumentException: No hudson.slaves.ComputerConnector implementation found for ssh
```
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
