### PR TITLE
[Issue #322] Change the way executors are calculated to fix indefinite pending queue

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -31,18 +31,13 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
         final Label label = strategyState.getLabel();
 
         final LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
-        final int availableCapacity =
-                snapshot.getAvailableExecutors()   // live executors
-                        + snapshot.getConnectingExecutors()  // executors present but not yet connected
-                        + strategyState.getPlannedCapacitySnapshot()     // capacity added by previous strategies from previous rounds
-                        + strategyState.getAdditionalPlannedCapacity();  // capacity added by previous strategies _this round_
+        final int availableCapacity = snapshot.getOnlineExecutors() + snapshot.getConnectingExecutors() - snapshot.getBusyExecutors()
 
         int currentDemand = snapshot.getQueueLength() - availableCapacity;
         LOGGER.log(currentDemand < 1 ? Level.FINE : Level.INFO,
-                "label [{0}]: currentDemand {1} availableCapacity {2} (availableExecutors {3} connectingExecutors {4} plannedCapacitySnapshot {5} additionalPlannedCapacity {6})",
-                new Object[]{label, currentDemand, availableCapacity, snapshot.getAvailableExecutors(),
-                        snapshot.getConnectingExecutors(), strategyState.getPlannedCapacitySnapshot(),
-                        strategyState.getAdditionalPlannedCapacity()});
+                "label [{0}]: currentDemand {1} availableCapacity {2} (onlineExecutors {3} connectingExecutors {4} busyExecutors {5} queueLength {6})",
+                new Object[]{label, currentDemand, availableCapacity, snapshot.getOnlineExecutors(),
+                        snapshot.getConnectingExecutors(), snapshot.getBusyExecutors(), snapshot.getQueueLength()});
 
         for (final Cloud cloud : getClouds()) {
             if (currentDemand < 1) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -31,7 +31,7 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
         final Label label = strategyState.getLabel();
 
         final LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
-        final int availableCapacity = snapshot.getOnlineExecutors() + snapshot.getConnectingExecutors() - snapshot.getBusyExecutors()
+        final int availableCapacity = snapshot.getOnlineExecutors() + snapshot.getConnectingExecutors() - snapshot.getBusyExecutors();
 
         int currentDemand = snapshot.getQueueLength() - availableCapacity;
         LOGGER.log(currentDemand < 1 ? Level.FINE : Level.INFO,


### PR DESCRIPTION
Change the way the executors are calculated by using the LoadStatisticsSnapshot rather than the strategyState object in Jenkins.  This way, the number of executors is directly calculated by the available and connecting executors minus the busy executors, rather than considering ambiguous pending, and additionally planned executors, that can create availability that doesn't actually exist.

### Testing done

Running this locally in our Jenkins instance for the last month without issue.  No further testing was done.

### Submitter checklist

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
