### PR TITLE
Fix logs and help

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineChecker.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineChecker.java
@@ -70,7 +70,7 @@ class EC2FleetOnlineChecker implements Runnable {
 
         if (timeout < 1 || interval < 1) {
             future.complete(node);
-            LOGGER.log(Level.INFO, String.format("Node '%s' connection check disabled. Resolving planned node", node.getNodeName()));
+            LOGGER.log(Level.INFO, String.format("Node '%s' connection check disabled. Resolving planned node", node.getDisplayName()));
             return;
         }
 
@@ -78,22 +78,22 @@ class EC2FleetOnlineChecker implements Runnable {
         if (computer != null) {
             if (computer.isOnline()) {
                 future.complete(node);
-                LOGGER.log(Level.INFO, String.format("Node '%s' connected. Resolving planned node", node.getNodeName()));
+                LOGGER.log(Level.INFO, String.format("Node '%s' connected. Resolving planned node", node.getDisplayName()));
                 return;
             }
         }
 
         if (System.currentTimeMillis() - start > timeout) {
             future.completeExceptionally(new IllegalStateException(
-                    "Failed to provision node. Could not connect to node '" + node.getNodeName() + "' before timeout (" + timeout + "ms)"));
+                    "Failed to provision node. Could not connect to node '" + node.getDisplayName() + "' before timeout (" + timeout + "ms)"));
             return;
         }
 
         if (computer == null) {
-            LOGGER.log(Level.INFO, String.format("No connection to node '%s'. Waiting before retry", node.getNodeName()));
+            LOGGER.log(Level.INFO, String.format("No connection to node '%s'. Waiting before retry", node.getDisplayName()));
         } else {
             computer.connect(false);
-            LOGGER.log(Level.INFO, String.format("No connection to node '%s'. Attempting to connect and waiting before retry", node.getNodeName()));
+            LOGGER.log(Level.INFO, String.format("No connection to node '%s'. Attempting to connect and waiting before retry", node.getDisplayName()));
         }
         EXECUTOR.schedule(this, interval, TimeUnit.MILLISECONDS);
     }

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-minSpareSize.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-minSpareSize.html
@@ -1,0 +1,9 @@
+<p>
+    Set a minimum spare size allowed.
+    The number of instances allowed to be idle / ready to pick up incoming jobs without having to wait for instances to start up.
+    These instances are exempt from 'Max Idle Minutes Before Scaledown' config.
+    'Maximum Cluster Size' is respected if 'Minimum Spare Size' exceeds it.
+</p>
+<p>
+    Default: 0 (No spare instances)
+</p>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineCheckerTest.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -41,7 +41,7 @@ public class EC2FleetOnlineCheckerTest {
 
     @Before
     public void before() throws Exception {
-        when(node.getNodeName()).thenReturn("i-1");
+        when(node.getDisplayName()).thenReturn("MockEC2FleetCloud i-1");
 
         PowerMockito.mockStatic(Jenkins.class);
 
@@ -73,7 +73,7 @@ public class EC2FleetOnlineCheckerTest {
             future.get();
             Assert.fail();
         } catch (InterruptedException | ExecutionException e) {
-            Assert.assertEquals("Failed to provision node. Could not connect to node 'i-1' before timeout (100ms)", e.getCause().getMessage());
+            Assert.assertEquals("Failed to provision node. Could not connect to node '" + node.getDisplayName() + "' before timeout (100ms)", e.getCause().getMessage());
             Assert.assertEquals(IllegalStateException.class, e.getCause().getClass());
             verify(computer, atLeast(2)).isOnline();
         }
@@ -93,17 +93,15 @@ public class EC2FleetOnlineCheckerTest {
         EC2FleetOnlineChecker.start(node, future, 0, 0);
 
         Assert.assertSame(node, future.get());
-        verifyZeroInteractions(computer);
+        verifyNoInteractions(computer);
     }
 
     @Test
     public void shouldSuccessfullyFinishAndNoWaitIfIntervalIsZero() throws ExecutionException, InterruptedException {
-        PowerMockito.when(computer.isOnline()).thenReturn(true);
-
         EC2FleetOnlineChecker.start(node, future, 10, 0);
 
         Assert.assertSame(node, future.get());
-        verifyZeroInteractions(computer);
+        verifyNoInteractions(computer);
     }
 
     @Test


### PR DESCRIPTION
### Changes
- Add clarity to EC2FleetOnlineChecker logs to replace node name `i-0123456789abcdefg` with node display name `EC2FleetCloud1 i-0123456789abcdefg` which includes the cloud name.
- Add help text to minSpareSize

### Testing done
Ran Jenkins with snapshot version of plugin and verified changes.

Before:
```
[INFO  ][com.amazon.jenkins.ec2fleet.EC2FleetOnlineChecker run] Node 'i-0123456789abcdefg' connected. Resolving planned node 
```

After:
```
[INFO  ][com.amazon.jenkins.ec2fleet.EC2FleetOnlineChecker run] Node 'EC2FleetCloud1 i-0123456789abcdefg' connected. Resolving planned node 
```
