### PR TITLE
[Fix] Fix computation of excess workload and available capacity

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -30,62 +30,63 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
         final Label label = strategyState.getLabel();
 
         final LoadStatistics.LoadStatisticsSnapshot snapshot = strategyState.getSnapshot();
-        final int availableCapacity =
-                snapshot.getAvailableExecutors()   // live executors
-                        + snapshot.getConnectingExecutors()  // executors present but not yet connected
-                        + strategyState.getPlannedCapacitySnapshot()     // capacity added by previous strategies from previous rounds
-                        + strategyState.getAdditionalPlannedCapacity();  // capacity added by previous strategies _this round_
+        final int availableCapacity = snapshot.getAvailableExecutors() // available executors
+                + strategyState.getPlannedCapacitySnapshot()     // capacity added by previous strategies from previous rounds
+                + strategyState.getAdditionalPlannedCapacity();  // capacity added by previous strategies _this round_
 
-        int currentDemand = snapshot.getQueueLength() - availableCapacity;
-        LOGGER.log(currentDemand < 1 ? Level.FINE : Level.INFO,
-                "label [{0}]: currentDemand {1} availableCapacity {2} (availableExecutors {3} connectingExecutors {4} plannedCapacitySnapshot {5} additionalPlannedCapacity {6})",
-                new Object[]{label, currentDemand, availableCapacity, snapshot.getAvailableExecutors(),
-                        snapshot.getConnectingExecutors(), strategyState.getPlannedCapacitySnapshot(),
-                        strategyState.getAdditionalPlannedCapacity()});
+        int qLen = snapshot.getQueueLength();
+        int excessWorkload = qLen - availableCapacity;
+        LOGGER.log(Level.FINE, "label [{0}]: queueLength {1} availableCapacity {2} (availableExecutors {3} plannedCapacitySnapshot {4} additionalPlannedCapacity {5})",
+                new Object[]{label, qLen, availableCapacity, snapshot.getAvailableExecutors(),
+                        strategyState.getPlannedCapacitySnapshot(), strategyState.getAdditionalPlannedCapacity()});
 
-        for (final Cloud cloud : getClouds()) {
-            if (currentDemand < 1) {
-                LOGGER.log(Level.FINE, "label [{0}]: currentDemand is less than 1, not provisioning", label);
+        if (excessWorkload <= 0) {
+            LOGGER.log(Level.INFO, "label [{0}]: No excess workload, provisioning not needed.", label);
+            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
+        }
+
+        for (final Cloud c : getClouds()) {
+            if (excessWorkload < 1) {
                 break;
             }
 
-            if (!(cloud instanceof EC2FleetCloud)) {
+            if (!(c instanceof EC2FleetCloud)) {
                 LOGGER.log(Level.FINE, "label [{0}]: cloud {1} is not an EC2FleetCloud, continuing...",
-                        new Object[]{label, cloud.getDisplayName()});
+                        new Object[]{label, c.getDisplayName()});
                 continue;
             }
 
             Cloud.CloudState cloudState = new Cloud.CloudState(label, strategyState.getAdditionalPlannedCapacity());
-            if (!cloud.canProvision(cloudState)) {
+            if (!c.canProvision(cloudState)) {
                 LOGGER.log(Level.INFO, "label [{0}]: cloud {1} can not provision for this label, continuing...",
-                        new Object[]{label, cloud.getDisplayName()});
+                        new Object[]{label, c.getDisplayName()});
                 continue;
             }
 
-            final EC2FleetCloud ec2 = (EC2FleetCloud) cloud;
-            if (!ec2.isNoDelayProvision()) {
+            if (!((EC2FleetCloud) c).isNoDelayProvision()) {
                 LOGGER.log(Level.FINE, "label [{0}]: cloud {1} does not use No Delay Provision Strategy, continuing...",
-                        new Object[]{label, cloud.getDisplayName()});
+                        new Object[]{label, c.getDisplayName()});
                 continue;
             }
 
-            LOGGER.log(Level.INFO, "label [{0}]: cloud {1} can provision for this label",
-                    new Object[]{label, cloud.getDisplayName()});
-            final Collection<NodeProvisioner.PlannedNode> plannedNodes = cloud.provision(cloudState, currentDemand);
-            for (NodeProvisioner.PlannedNode plannedNode : plannedNodes) {
-                currentDemand -= plannedNode.numExecutors;
+            LOGGER.log(Level.FINE, "label [{0}]: cloud {1} can provision for this label",
+                    new Object[]{label, c.getDisplayName()});
+            final Collection<NodeProvisioner.PlannedNode> plannedNodes = c.provision(cloudState, excessWorkload);
+            for (NodeProvisioner.PlannedNode pn : plannedNodes) {
+                excessWorkload -= pn.numExecutors;
+                LOGGER.log(Level.INFO, "Started provisioning {0} from {1} with {2,number,integer} "
+                                + "executors. Remaining excess workload: {3,number,#.###}",
+                        new Object[]{pn.displayName, c.name, pn.numExecutors, excessWorkload});
             }
-            LOGGER.log(Level.FINE, "Planned {0} new nodes", plannedNodes.size());
             strategyState.recordPendingLaunches(plannedNodes);
-            LOGGER.log(Level.FINE, "After provisioning currentDemand={0}", new Object[]{currentDemand});
         }
 
-        if (currentDemand < 1) {
-            LOGGER.log(Level.FINE, "Provisioning completed");
-            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
-        } else {
+        if (excessWorkload > 0) {
             LOGGER.log(Level.FINE, "Provisioning not complete, consulting remaining strategies");
             return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
+        } else {
+            LOGGER.log(Level.FINE, "Provisioning completed");
+            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
         }
     }
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/NoDelayProvisionStrategy.java
@@ -84,10 +84,10 @@ public class NoDelayProvisionStrategy extends NodeProvisioner.Strategy {
         if (excessWorkload > 0) {
             LOGGER.log(Level.FINE, "Provisioning not complete, consulting remaining strategies");
             return NodeProvisioner.StrategyDecision.CONSULT_REMAINING_STRATEGIES;
-        } else {
-            LOGGER.log(Level.FINE, "Provisioning completed");
-            return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
         }
+
+        LOGGER.log(Level.FINE, "Provisioning completed");
+        return NodeProvisioner.StrategyDecision.PROVISIONING_COMPLETED;
     }
 
     // Visible for testing


### PR DESCRIPTION
### Description
The plugin computes current demand and available capacity in order to identify excess workload and provision capacity for it. This code is run when jobs are added to queues.
Problems with current computations:
- Available capacity includes both `connectingExecutors` and `plannedCapacitySnapshot`. This can lead to availableCapacity being much higher than reality, esp. for huge fleets and a  busy Jenkins with numerous builds running / queued.
- Current demand changes as capacity is provisioned but queue length remains same. This can be misleading and makes code and logs less readable, especially when dealing with negative current demand.
```
com.amazon.jenkins.ec2fleet.NoDelayProvisionStrategy apply In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, 
snapshot=LoadStatisticsSnapshot{definedExecutors=0, onlineExecutors=0, connectingExecutors=0, busyExecutors=0, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}

currentDemand 1 availableCapacity 0 (availableExecutors 0 connectingExecutors 0 plannedCapacitySnapshot 0 additionalPlannedCapacity 0)

com.amazon.jenkins.ec2fleet.NoDelayProvisionStrategy apply In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, 
snapshot=LoadStatisticsSnapshot{definedExecutors=0, onlineExecutors=0, connectingExecutors=2, busyExecutors=0, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=2, additionalPlannedCapacity=0}

currentDemand -3 availableCapacity 4 (availableExecutors 0 connectingExecutors 2 plannedCapacitySnapshot 2 additionalPlannedCapacity 0)
```
- Logs are misleading, show `provisioning completed` messages after planning to provision.


##### Context: 
The plugin keeps track of new capacity planned to provision with `plannedCapacitySnapshot`, [which is required to avoid over-provisioning](https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineChecker.java#LL15C1-L32C7). The plugin also controls when the Java futures for planned nodes are resolved - after Jenkins has [established a connection](https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineChecker.java#LL80C24-L80C24) to the new node or connection [fails due to timeout](https://github.com/jenkinsci/ec2-fleet-plugin/blob/master/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetOnlineChecker.java#L87) i.e.`plannedCapacitySnapshot` includes nodes in ‘connecting’ state. 

Reference of other plugins:
- Ec2-plugin: (doesn’t change what’s tracked in plannedCapacitySnapshot) - https://github.com/jenkinsci/ec2-plugin/blob/master/src/main/java/hudson/plugins/ec2/NoDelayProvisionerStrategy.java#L31 
- Kubernetes-plugin - https://github.com/jenkinsci/kubernetes-ci-plugin/blob/master/src/main/java/com/elasticbox/jenkins/k8s/plugin/slaves/KubernetesSlaveProvisioningStrategy.java#L24  

##### Related Issues:
- https://github.com/jenkinsci/ec2-fleet-plugin/issues/322
- https://github.com/jenkinsci/ec2-fleet-plugin/issues/359

### Testing done
Tested that results match expectations with a snapshot version of the plugin with:
- various configurations
- changing plugin config
- scaling ASG directly in AWS console 
- multiple Jenkins (free style) projects

### Sample logs:

- excess workload:
```
>> Provisioning:
In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, snapshot=LoadStatisticsSnapshot{definedExecutors=2, onlineExecutors=2, connectingExecutors=0, busyExecutors=2, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}  
label [spot-workers]: queueLength 1 availableCapacity 0 (availableExecutors 0 plannedCapacitySnapshot 0 additionalPlannedCapacity 0)  
EC2FleetCloud [spot-workers] excessWorkload 1  
EC2FleetCloud [spot-workers] to provision = 1  
Planned 1 new nodes  
Started provisioning FleetNode-EC2FleetCloud-6 from EC2FleetCloud with 1 executors. Remaining excess workload: 0  
Provisioning completed 

>> Update cycle (actual provisioning using EC2 APIs):
EC2FleetCloud [spot-workers] start cloud com.amazon.jenkins.ec2fleet.EC2FleetCloud@2a1fd5ad  
EC2FleetCloud [spot-workers] Set target capacity to '3'  

>> ... After successful connection...

[hudson.slaves.NodeProvisioner lambda$update$6] FleetNode-EC2FleetCloud-3 provisioning successfully completed. We have now 4 computer(s)  
```

Before: 
```
In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=3, connectingExecutors=0, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=0, additionalPlannedCapacity=0}  
label [spot-workers]: currentDemand 1 availableCapacity 0 (availableExecutors 0 connectingExecutors 0 plannedCapacitySnapshot 0 additionalPlannedCapacity 0)  
EC2FleetCloud [spot-workers] excessWorkload 1  
EC2FleetCloud [spot-workers] to provision = 1  
Planned 1 new nodes  
After provisioning currentDemand=-1  
label [spot-workers]: currentDemand is less than 1, not provisioning  
Provisioning completed  
```

- no excess workload:

```
In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, snapshot=LoadStatisticsSnapshot{definedExecutors=5, onlineExecutors=3, connectingExecutors=0, busyExecutors=3, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=2, additionalPlannedCapacity=0}  
label [spot-workers]: queueLength 1 availableCapacity 2 (availableExecutors 0 plannedCapacitySnapshot 2 additionalPlannedCapacity 0)  
label [spot-workers]: No excess workload, provisioning not needed. 
```

Before:

```
In NodeProvisioner.StrategyDecision -> apply StrategyState{label=spot-workers, snapshot=LoadStatisticsSnapshot{definedExecutors=3, onlineExecutors=2, connectingExecutors=0, busyExecutors=2, idleExecutors=0, availableExecutors=0, queueLength=1}, plannedCapacitySnapshot=1, additionalPlannedCapacity=0}  
label [spot-workers]: currentDemand 0 availableCapacity 1 (availableExecutors 0 connectingExecutors 0 plannedCapacitySnapshot 1 additionalPlannedCapacity 0)  
label [spot-workers]: currentDemand is less than 1, not provisioning  
Provisioning completed  
```
