### PR TITLE
Fix 363

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.ec2.AmazonEC2;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.InstanceStateName;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
+import com.google.common.collect.Sets;
 import hudson.Extension;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -51,6 +52,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
+import java.util.stream.Collectors;
 
 /**
  * @see CloudNanny
@@ -212,7 +214,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         this.minSize = Math.max(0, minSize);
         this.maxSize = maxSize;
         this.minSpareSize = Math.max(0, minSpareSize);
-        this.maxTotalUses = StringUtils.isBlank(maxTotalUses) ? -1 : Integer.parseInt(maxTotalUses);
+        this.maxTotalUses = StringUtils.isBlank(maxTotalUses) ? DEFAULT_MAX_TOTAL_USES : Integer.parseInt(maxTotalUses);
         this.numExecutors = Math.max(numExecutors, 1);
         this.addNodeOnlyIfRunning = addNodeOnlyIfRunning;
         this.restrictUsage = restrictUsage;
@@ -282,10 +284,6 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
     public String getEndpoint() {
         return endpoint;
-    }
-
-    public int getMaxTotalUses() {
-        return maxTotalUses == null ? DEFAULT_MAX_TOTAL_USES : maxTotalUses;
     }
 
     @Override
@@ -380,6 +378,11 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     // Visible for testing
     synchronized void setStats(final FleetStateStats stats) {
         this.stats = stats;
+    }
+
+    // make maxTotalUses inaccessible from cloud for safety. Use {@link EC2FleetNode#maxTotalUses} and {@link EC2FleetNode#usesRemaining} instead.
+    public boolean hasUnlimitedUsesForNodes() {
+        return maxTotalUses == -1;
     }
 
     @Override
@@ -502,7 +505,25 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 }
             }
             currentToAdd = toAdd;
-            currentInstanceIdsToTerminate = new HashMap<>(instanceIdsToTerminate);
+
+            // for computers currently busy doing work, wait until next update cycle to terminate corresponding instances (issue#363).
+            final Jenkins j = Jenkins.get();
+            currentInstanceIdsToTerminate = instanceIdsToTerminate.entrySet()
+                    .stream()
+                    .filter(e -> {
+                        final Node node = j.getNode(e.getKey());
+                        if (node != null) {
+                            final Computer comp = node.toComputer();
+                            return comp == null || comp.isIdle();
+                        }
+                        return true;
+                    })
+                    .collect(Collectors.toMap(Map.Entry::getKey,Map.Entry::getValue));
+
+            final Set<String> filteredOutNonIdleIds = Sets.difference(instanceIdsToTerminate.keySet(), currentInstanceIdsToTerminate.keySet());
+            if (filteredOutNonIdleIds.size() > 0) {
+                info("Skipping termination of the following instances as they are still busy doing some work: %s", filteredOutNonIdleIds);
+            }
         }
 
         currentState = updateByState(currentToAdd, currentInstanceIdsToTerminate, currentState);
@@ -829,7 +850,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Node.Mode nodeMode = restrictUsage ? Node.Mode.EXCLUSIVE : Node.Mode.NORMAL;
         final EC2FleetNode node = new EC2FleetNode(instanceId, "Fleet slave for " + instanceId,
                 effectiveFsRoot, effectiveNumExecutors, nodeMode, labelString, new ArrayList<NodeProperty<?>>(),
-                this, computerLauncher, getMaxTotalUses());
+                this, computerLauncher, maxTotalUses);
 
         // Initialize our retention strategy
         node.setRetentionStrategy(new EC2RetentionStrategy());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNode.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNode.java
@@ -17,7 +17,8 @@ import java.util.List;
 public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudAware {
 
     private volatile AbstractEC2FleetCloud cloud;
-    private int maxTotalUses;
+    private final int maxTotalUses;
+    private int usesRemaining;
 
     public EC2FleetNode(final String name, final String nodeDescription, final String remoteFS, final int numExecutors, final Mode mode, final String label,
                         final List<? extends NodeProperty<?>> nodeProperties, final AbstractEC2FleetCloud cloud, ComputerLauncher launcher, final int maxTotalUses) throws IOException, Descriptor.FormException {
@@ -26,6 +27,7 @@ public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudA
                 launcher, RetentionStrategy.NOOP, nodeProperties);
         this.cloud = cloud;
         this.maxTotalUses = maxTotalUses;
+        this.usesRemaining = maxTotalUses;
     }
 
     @Override
@@ -61,8 +63,12 @@ public class EC2FleetNode extends Slave implements EphemeralNode, EC2FleetCloudA
         return this.maxTotalUses;
     }
 
-    public void setMaxTotalUses(final int maxTotalUses) {
-        this.maxTotalUses = maxTotalUses;
+    public int getUsesRemaining() {
+        return usesRemaining;
+    }
+
+    public void decrementUsesRemaining() {
+        this.usesRemaining--;
     }
 
     @Extension


### PR DESCRIPTION
## Changes:
- terminate scheduled instances ONLY IF idle - 363 
- leave maxTotalUses alone and track remainingUses correctly
   -  Make maxTotalUses read-only
   - Allow only decrementing remainingUses by 1 
   - Add a flag to track manual termination of agents

## Testing:
- tested changes in my jenkins setup with snapshot version of plugin.  
- added unit and integration tests

See passing checks here - https://github.com/jenkinsci/ec2-fleet-plugin/pull/376/checks 