### PR TITLE
Fix #335

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -102,7 +102,7 @@ public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLaun
 
                     final List<Action> actions = new ArrayList<>();
                     if (task instanceof WorkflowJob) {
-                        final WorkflowRun failedBuild = ((WorkflowJob) task).getLastBuild();
+                        final WorkflowRun failedBuild = ((WorkflowJob) task).getLastFailedBuild();
                         actions.addAll(failedBuild.getActions(ParametersAction.class));
                     }
                     if (executable instanceof Actionable) {


### PR DESCRIPTION
Handling following issue - https://github.com/jenkinsci/ec2-fleet-plugin/issues/335.

Note that this is an improvement on the previous implementation for rescheduling failed builds, which would reschedule using the last build parameters, which may be different than the build that actually failed. However, this is not a catch all fix. If multiple builds fail, then a build may be re-scheduled with parameters of another failed build. Will open a separate issue to track further fixes that can be done here.

### Testing done

Submitted build 1, changed build parameters and submitted build 2, terminated instance running build 1 and verified last failed build is set to build 1. Verified re-scheduled build uses parameters from build 1.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X ] Ensure that the pull request title represents the desired changelog entry
- [ X ] Please describe what you did
- [ X ] Link to relevant issues in GitHub or Jira
- [ X ] Link to relevant pull requests, esp. upstream and downstream changes
- [ X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
