### PR TITLE
Handling issue #387 - making cloud name unmodifiable once set initially

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -958,7 +958,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             return FormValidation.error("Maximum Total Uses must be greater or equal to -1");
         }
 
-        public FormValidation doCheckCloudName(@QueryParameter final String name) {
+        public FormValidation doCheckName(@QueryParameter final String name) {
             try {
                 Jenkins.checkGoodName(name);
             } catch (Failure e) {

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -5,9 +5,9 @@
          xmlns:c="/lib/credentials">
 
     <f:description>A unique name for this EC2 Fleet cloud</f:description>
-    <f:description>Warning: Cloud name is used to track agents belonging to this cloud. Please do not modify an existing cloud's name. See <a href="https://github.com/jenkinsci/ec2-fleet-plugin/issues/382">this issue</a> for details</f:description>
+    <f:description>Warning: Cloud name is used to track agents belonging to this cloud. Once set, it will be be unmodifiable. See <a href="https://github.com/jenkinsci/ec2-fleet-plugin/issues/387">this issue</a> for details</f:description>
     <f:entry title="${%Name}" field="name">
-        <f:textbox default="FleetCloud"/>
+      <f:textbox readonly="${instance != null ? 'readonly' : null}"/>
     </f:entry>
 
     <f:description>Select AWS Credentials or leave set to none to use <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS EC2 Instance Role</a></f:description>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-name.html
@@ -1,5 +1,5 @@
 <div>
-    Provide a name for this EC2 Fleet Cloud
+    Provide a name for this EC2 Fleet Cloud/EC2 Fleet Label Cloud. If no name is provided, then a default of 'FleetCloud' for a EC2FleetCloud or 'FleetCloudLabel' for a EC2FleetLabelCloud will be used for the name.
 
     <p>
         Could be used in Groovy as cloud identifier.

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
@@ -5,9 +5,9 @@
          xmlns:c="/lib/credentials">
 
     <f:description>A unique name for this EC2 Fleet label cloud</f:description>
-    <f:description>Warning: Cloud name is used to track agents belonging to this cloud. Please do not modify an existing cloud's name. See <a href="https://github.com/jenkinsci/ec2-fleet-plugin/issues/382">this issue</a> for details</f:description>
+    <f:description>Warning: Cloud name is used to track agents belonging to this cloud. Once set, it will be be unmodifiable. See <a href="https://github.com/jenkinsci/ec2-fleet-plugin/issues/387">this issue</a> for details</f:description>
     <f:entry title="${%Name}" field="name">
-        <f:textbox default="FleetCloudLabel"/>
+      <f:textbox readonly="${instance != null ? 'readonly' : null}"/>
     </f:entry>
 
     <f:description>Select AWS Credentials or leave set to none to use <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html">AWS EC2 Instance Role</a></f:description>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -1889,6 +1889,18 @@ public class EC2FleetCloudTest {
     }
 
     @Test
+    public void descriptorImpl_doCheckFleetName_validName() {
+        FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doCheckFleet("FleetCloud");
+        assertEquals(formValidation.kind, Kind.OK);
+    }
+
+    @Test
+    public void descriptorImpl_doCheckFleetName_invalidName() {
+        FormValidation formValidation = new EC2FleetCloud.DescriptorImpl().doCheckFleet(null);
+        assertEquals(formValidation.kind, Kind.ERROR);
+    }
+
+    @Test
     public void descriptorImpl_doFillFleetItems_returnEmptyListIfNoEmptyEC2Fleet() {
         ListBoxModel r = new EC2FleetCloud.DescriptorImpl().doFillFleetItems(
                 false, "", "", "", "");

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -112,6 +112,7 @@ public class UiIntegrationTest {
         HtmlFormUtil.submit(form);
 
         final Cloud newCloud = j.jenkins.clouds.get(0);
+        assertNotNull(newCloud);
         assertNotSame(cloud, newCloud);
         assertSame(newCloud, ((EC2FleetNode) j.jenkins.getNode("mock")).getCloud());
     }
@@ -293,30 +294,18 @@ public class UiIntegrationTest {
         assertSame(cloud2, j.jenkins.getCloud("b"));
     }
 
-    // This is expected behavior until https://github.com/jenkinsci/ec2-fleet-plugin/issues/382 is addressed.
-    // Current mitigation in place: A warning message is displayed next to the cloud name field in the UI.
-    // No mitigation for configuration as code users.
     @Test
-    public void verifyCloudNameNotReplacedWhenChangedForNodesAfterConfigurationSave() throws Exception {
+    public void verifyCloudNameReadOnlyAfterCloudCreated() throws Exception {
         EC2FleetCloud cloud = new EC2FleetCloud("test-cloud", null, null, null, null, "",
-                "label", null, null, false, false,
-                0, 0, 0, 0, 0, true, false,
-                "-1", false, 0, 0, false,
-                10, false);
+            "label", null, null, false, false,
+            0, 0, 0, 0, 0, true, false,
+            "-1", false, 0, 0, false,
+            10, false);
         j.jenkins.clouds.add(cloud);
 
-        j.jenkins.addNode(new EC2FleetNode("mock", "", "", 1,
-                Node.Mode.EXCLUSIVE, "", new ArrayList<NodeProperty<?>>(), cloud.name,
-                j.createComputerLauncher(null), -1));
-
         HtmlPage page = j.createWebClient().goTo("configureClouds");
-        HtmlForm form = page.getFormByName("config");
 
-        ((HtmlTextInput) IntegrationTest.getElementsByNameWithoutJdk(page, "_.name").get(0)).setText("new-cloud-name");
-        HtmlFormUtil.submit(form);
-
-        final Cloud newCloud = j.jenkins.clouds.get(0);
-        assertNotSame(cloud, newCloud);
-        assertNotSame(newCloud.name, ((EC2FleetNode) j.jenkins.getNode("mock")).getCloudName());
+        List<DomElement> elementsByName = IntegrationTest.getElementsByNameWithoutJdk(page, "_.name");
+        assertTrue(((HtmlTextInput) elementsByName.get(0)).isReadOnly());
     }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Handling issue #387 

- This change will make cloud name unmodifiable once a cloud object is created. Once a cloud object is created, the `configureClouds` page will make the name textbox readOnly

- Also, fixing validation on cloud name by changing check method from `doCheckCloudName` -> `doCheckName`

- If no cloud name is provided, then a default cloud name of "FleetCloud" and "FleetCloudLabel" will be used respectively for an EC2FleetCloud and EC2FleetLabelCloud

- The default textbox when a cloud is created will now be blank rather than "FleetCloud"/"FleetCloudLabel". The default name will be handled in the java code, rather than in two separate locations as is now.

### Testing done

- Unit Tests

- Created and saved cloud, reloaded configureClouds and verified textbox is readOnly

- Created and saved cloud, updated separate property, and verified name is unchanged

- Verified when cloud is first created that a validation error is present to specify name.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X ] Ensure that the pull request title represents the desired changelog entry
- [ X ] Please describe what you did
- [ X ] Link to relevant issues in GitHub or Jira
- [ X ] Link to relevant pull requests, esp. upstream and downstream changes
- [ X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
