### PR TITLE
making existing duplicate cloud name editable as part of fixes for cloud tracking

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
@@ -1,5 +1,8 @@
 package com.amazon.jenkins.ec2fleet;
 
+import hudson.slaves.Cloud;
+import java.util.ArrayList;
+import java.util.HashSet;
 import jenkins.model.Jenkins;
 
 import java.util.Collections;
@@ -10,6 +13,17 @@ public class CloudNames {
 
   public static Boolean isUnique(final String name) {
     return !Jenkins.get().clouds.stream().anyMatch(c -> c.name.equals(name));
+  }
+
+  public static Boolean isExistingUnique(final String name) {
+    int found = 0;
+    for (Cloud c : Jenkins.get().clouds) {
+      if (c.name.equals(name)) {
+        found++;
+      }
+    }
+
+    return !(found > 1);
   }
 
   public static String generateUnique(final String defaultName) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
@@ -1,8 +1,6 @@
 package com.amazon.jenkins.ec2fleet;
 
 import hudson.slaves.Cloud;
-import java.util.ArrayList;
-import java.util.HashSet;
 import jenkins.model.Jenkins;
 
 import java.util.Collections;
@@ -15,16 +13,7 @@ public class CloudNames {
     return !Jenkins.get().clouds.stream().anyMatch(c -> c.name.equals(name));
   }
 
-  public static Boolean isExistingUnique(final String name) {
-    int found = 0;
-    for (Cloud c : Jenkins.get().clouds) {
-      if (c.name.equals(name)) {
-        found++;
-      }
-    }
-
-    return !(found > 1);
-  }
+  public static Boolean isDuplicated(final String name) { return Jenkins.get().clouds.stream().filter(c -> c.name.equals(name)).count() > 1; }
 
   public static String generateUnique(final String defaultName) {
     final Set<String> usedNames = Jenkins.get().clouds != null

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -969,6 +969,11 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             if (Boolean.valueOf(isNewCloud) && !CloudNames.isUnique(name)) {
                 return FormValidation.error("Please choose a unique name. Existing clouds: " + Jenkins.get().clouds.stream().map(c -> c.name).collect(Collectors.joining(",")));
             }
+            else if (!Boolean.valueOf(isNewCloud) && !CloudNames.isExistingUnique(name)) {
+                Set<String> uniqueNames = new HashSet<>();
+                Jenkins.get().clouds.forEach(cloud -> {uniqueNames.add(cloud.name);});
+                return FormValidation.error("Existing cloud name is duplicated. Please update to unique names. Existing names: " + uniqueNames);
+            }
 
             return FormValidation.ok();
         }
@@ -996,6 +1001,8 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         public String getDefaultCloudName() {
             return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
         }
+
+        public Boolean isExistingCloudUnique(@QueryParameter final String name) { return CloudNames.isExistingUnique(name); }
 
         public FormValidation doCheckFleet(@QueryParameter final String fleet) {
             if (StringUtils.isEmpty(fleet)) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -1002,7 +1002,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
         }
 
-        public Boolean isExistingCloudDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
+        public Boolean isExistingCloudNameDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
 
         public FormValidation doCheckFleet(@QueryParameter final String fleet) {
             if (StringUtils.isEmpty(fleet)) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -969,10 +969,10 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             if (Boolean.valueOf(isNewCloud) && !CloudNames.isUnique(name)) {
                 return FormValidation.error("Please choose a unique name. Existing clouds: " + Jenkins.get().clouds.stream().map(c -> c.name).collect(Collectors.joining(",")));
             }
-            else if (!Boolean.valueOf(isNewCloud) && !CloudNames.isExistingUnique(name)) {
+            else if (!Boolean.valueOf(isNewCloud) && CloudNames.isDuplicated(name)) {
                 Set<String> uniqueNames = new HashSet<>();
                 Jenkins.get().clouds.forEach(cloud -> {uniqueNames.add(cloud.name);});
-                return FormValidation.error("Existing cloud name is duplicated. Please update to unique names. Existing names: " + uniqueNames);
+                return FormValidation.error("This cloud name is not unique. Please choose a unique name and click save. Existing clouds: " + uniqueNames);
             }
 
             return FormValidation.ok();
@@ -1002,7 +1002,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
             return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
         }
 
-        public Boolean isExistingCloudUnique(@QueryParameter final String name) { return CloudNames.isExistingUnique(name); }
+        public Boolean isExistingCloudDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
 
         public FormValidation doCheckFleet(@QueryParameter final String fleet) {
             if (StringUtils.isEmpty(fleet)) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -863,6 +863,11 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             if (Boolean.valueOf(isNewCloud) && !CloudNames.isUnique(name)) {
                 return FormValidation.error("Please choose a unique name. Existing clouds: " + Jenkins.get().clouds.stream().map(c -> c.name).collect(Collectors.joining(",")));
             }
+            else if (!Boolean.valueOf(isNewCloud) && CloudNames.isDuplicated(name)) {
+                Set<String> uniqueNames = new HashSet<>();
+                Jenkins.get().clouds.forEach(cloud -> {uniqueNames.add(cloud.name);});
+                return FormValidation.error("This cloud name is not unique. Please choose a unique name and click save. Existing clouds: " + uniqueNames);
+            }
 
             return FormValidation.ok();
         }
@@ -870,6 +875,8 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         public String getDefaultCloudName() {
             return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
         }
+
+        public Boolean isExistingCloudDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
 
         @Override
         public boolean configure(final StaplerRequest req, final JSONObject formData) throws FormException {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -876,7 +876,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
         }
 
-        public Boolean isExistingCloudDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
+        public Boolean isExistingCloudNameDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }
 
         @Override
         public boolean configure(final StaplerRequest req, final JSONObject formData) throws FormException {

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="${%Name}" field="name">
         <j:choose>
-            <j:when test="${instance != null}">
+            <j:when test="${instance != null and descriptor.isExistingCloudUnique(instance.name)}">
                 <!-- Warning: Using <j:set var="readOnlyMode" value="true"/> instead of readOnlyTextbox shows some weird, hard-to-debug behavior where it makes the name null for existing clouds when a new cloud is created.-->
                 <f:readOnlyTextbox/>
             </j:when>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="${%Name}" field="name">
         <j:choose>
-            <j:when test="${instance != null and descriptor.isExistingCloudUnique(instance.name)}">
+            <j:when test="${instance != null and not descriptor.isExistingCloudDuplicated(instance.name)}">
                 <!-- Warning: Using <j:set var="readOnlyMode" value="true"/> instead of readOnlyTextbox shows some weird, hard-to-debug behavior where it makes the name null for existing clouds when a new cloud is created.-->
                 <f:readOnlyTextbox/>
             </j:when>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="${%Name}" field="name">
         <j:choose>
-            <j:when test="${instance != null and not descriptor.isExistingCloudDuplicated(instance.name)}">
+            <j:when test="${instance != null and not descriptor.isExistingCloudNameDuplicated(instance.name)}">
                 <!-- Warning: Using <j:set var="readOnlyMode" value="true"/> instead of readOnlyTextbox shows some weird, hard-to-debug behavior where it makes the name null for existing clouds when a new cloud is created.-->
                 <f:readOnlyTextbox/>
             </j:when>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="${%Name}" field="name">
         <j:choose>
-            <j:when test="${instance != null}">
+            <j:when test="${instance != null and not descriptor.isExistingCloudDuplicated(instance.name)}">
                 <!-- Warning: Using <j:set var="readOnlyMode" value="true"/> instead of readOnlyTextbox shows some weird, hard-to-debug behavior where it makes the name null for existing clouds when a new cloud is created.-->
                 <f:readOnlyTextbox/>
             </j:when>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud/config.jelly
@@ -13,7 +13,7 @@
 
     <f:entry title="${%Name}" field="name">
         <j:choose>
-            <j:when test="${instance != null and not descriptor.isExistingCloudDuplicated(instance.name)}">
+            <j:when test="${instance != null and not descriptor.isExistingCloudNameDuplicated(instance.name)}">
                 <!-- Warning: Using <j:set var="readOnlyMode" value="true"/> instead of readOnlyTextbox shows some weird, hard-to-debug behavior where it makes the name null for existing clouds when a new cloud is created.-->
                 <f:readOnlyTextbox/>
             </j:when>

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
@@ -32,6 +32,34 @@ public class CloudNamesTest {
   }
 
   @Test
+  public void isExistingUnique_true() {
+    j.jenkins.clouds.add(new EC2FleetCloud("TestCloud", null, null, null, null, null,
+        "test-label", null, null, false, false,
+        0, 0, 0, 0, 0, true, false,
+        "-1", false, 0, 0, false,
+        10, false));
+
+    Assert.assertTrue(CloudNames.isExistingUnique("TestCloud"));
+  }
+
+  @Test
+  public void isExistingUnique_false() {
+    j.jenkins.clouds.add(new EC2FleetCloud("TestCloud", null, null, null, null, null,
+        "test-label", null, null, false, false,
+        0, 0, 0, 0, 0, true, false,
+        "-1", false, 0, 0, false,
+        10, false));
+
+    j.jenkins.clouds.add(new EC2FleetCloud("TestCloud", null, null, null, null, null,
+        "test-label", null, null, false, false,
+        0, 0, 0, 0, 0, true, false,
+        "-1", false, 0, 0, false,
+        10, false));
+
+    Assert.assertFalse(CloudNames.isExistingUnique("TestCloud"));
+  }
+
+  @Test
   public void generateUnique_noSuffix() {
     Assert.assertEquals("FleetCloud", CloudNames.generateUnique("FleetCloud"));
   }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
@@ -32,18 +32,24 @@ public class CloudNamesTest {
   }
 
   @Test
-  public void isExistingUnique_true() {
+  public void isDuplicated_false() {
     j.jenkins.clouds.add(new EC2FleetCloud("TestCloud", null, null, null, null, null,
         "test-label", null, null, false, false,
         0, 0, 0, 0, 0, true, false,
         "-1", false, 0, 0, false,
         10, false));
 
-    Assert.assertTrue(CloudNames.isExistingUnique("TestCloud"));
+    j.jenkins.clouds.add(new EC2FleetCloud("TestCloud2", null, null, null, null, null,
+        "test-label", null, null, false, false,
+        0, 0, 0, 0, 0, true, false,
+        "-1", false, 0, 0, false,
+        10, false));
+
+    Assert.assertFalse(CloudNames.isDuplicated("TestCloud"));
   }
 
   @Test
-  public void isExistingUnique_false() {
+  public void isDuplicated_true() {
     j.jenkins.clouds.add(new EC2FleetCloud("TestCloud", null, null, null, null, null,
         "test-label", null, null, false, false,
         0, 0, 0, 0, 0, true, false,
@@ -56,7 +62,7 @@ public class CloudNamesTest {
         "-1", false, 0, 0, false,
         10, false));
 
-    Assert.assertFalse(CloudNames.isExistingUnique("TestCloud"));
+    Assert.assertTrue(CloudNames.isDuplicated("TestCloud"));
   }
 
   @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/UiIntegrationTest.java
@@ -32,6 +32,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
@@ -307,5 +308,25 @@ public class UiIntegrationTest {
 
         List<DomElement> elementsByName = IntegrationTest.getElementsByNameWithoutJdk(page, "_.name");
         assertTrue(((HtmlTextInput) elementsByName.get(0)).isReadOnly());
+    }
+
+    @Test
+    public void verifyExistingDuplicateCloudNamesEditable() throws Exception {
+        j.jenkins.clouds.add(new EC2FleetCloud("test-cloud", null, null, null, null, "",
+            "label", null, null, false, false,
+            0, 0, 0, 0, 0, true, false,
+            "-1", false, 0, 0, false,
+            10, false));
+        j.jenkins.clouds.add(new EC2FleetCloud("test-cloud", null, null, null, null, "",
+            "label", null, null, false, false,
+            0, 0, 0, 0, 0, true, false,
+            "-1", false, 0, 0, false,
+            10, false));
+
+        HtmlPage page = j.createWebClient().goTo("configureClouds");
+
+        List<DomElement> elementsByName = IntegrationTest.getElementsByNameWithoutJdk(page, "_.name");
+        assertFalse(((HtmlTextInput) elementsByName.get(0)).isReadOnly());
+        assertFalse(((HtmlTextInput) elementsByName.get(1)).isReadOnly());
     }
 }


### PR DESCRIPTION
Make existing clouds with duplicate names editable for UI users. As part of changes to [fix cloud tracking](https://github.com/jenkinsci/ec2-fleet-plugin/pull/383), cloud name must be unique across all clouds. As users update to the new release, existing clouds may have the same name, so must be editable in order to update to unique names. Once the new unique names are set, then cloud name is final.

I could not find a great way to prevent jenkins from running or have a popup indicating to users upgrading the new jenkins release to check if there cloud names are unique. As part of a troubleshooting or upgrade guide, users can be guided to update any existing clouds with duplicate names.

### Testing done

- Unit tests
- Created existing unique clouds and verified cloud name is editable, then becomes read-only once updating the names
- Verified new cloud name text box is not read-only on creation

<img width="1280" alt="Screen Shot 2023-08-22 at 2 07 04 AM" src="https://github.com/jenkinsci/ec2-fleet-plugin/assets/35543771/1ac1cb62-2a00-472e-95c5-25e043c8b433">

```[tasklist]
### Submitter checklist
- [ X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X ] Ensure that the pull request title represents the desired changelog entry
- [ X ] Please describe what you did
- [ X ] Link to relevant issues in GitHub or Jira
- [ X ] Link to relevant pull requests, esp. upstream and downstream changes
- [ X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
