### PR TITLE
cleaned up suffix generation for CloudNames and default name for CasC

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/CloudNames.java
@@ -2,12 +2,18 @@ package com.amazon.jenkins.ec2fleet;
 
 import hudson.slaves.Cloud;
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.RandomStringUtils;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CloudNames {
+
+  public static final int SUFFIX_LENGTH = 8;
+
+  private static final Set<String> usedSuffixes = new HashSet<String>();
 
   public static Boolean isUnique(final String name) {
     return !Jenkins.get().clouds.stream().anyMatch(c -> c.name.equals(name));
@@ -15,17 +21,32 @@ public class CloudNames {
 
   public static Boolean isDuplicated(final String name) { return Jenkins.get().clouds.stream().filter(c -> c.name.equals(name)).count() > 1; }
 
-  public static String generateUnique(final String defaultName) {
+  public static String generateUnique(final String proposedName) {
     final Set<String> usedNames = Jenkins.get().clouds != null
             ? Jenkins.get().clouds.stream().map(c -> c.name).collect(Collectors.toSet())
             : Collections.emptySet();
-    String uniqName = defaultName;
 
-    int suffix = 1;
-    while (usedNames.contains(uniqName)) {
-      uniqName = defaultName + "-" + suffix++;
+    if (proposedName.equals(EC2FleetCloud.BASE_DEFAULT_FLEET_CLOUD_ID) || proposedName.equals(EC2FleetLabelCloud.BASE_DEFAULT_FLEET_CLOUD_ID) || usedNames.contains(proposedName)) {
+      return proposedName + "-" + generateSuffix();
     }
 
-    return uniqName;
+    return proposedName;
+  }
+  
+  /**
+   * We are using a randomly generated string as a suffix here because Jenkins creates its clouds as a batch.
+   * This functionality means if a CasC user has two empty strings for the name field prompting two clouds with 
+   * default names, they would theoretically have the same default name. By appending a random suffix we can be 
+   * sure w.h.p that the suffixes created will be different.
+   */
+  private static String generateSuffix() {
+    String suffix;
+
+    do {
+      suffix = RandomStringUtils.randomAlphanumeric(SUFFIX_LENGTH);
+    } while (usedSuffixes.contains(suffix));
+
+    usedSuffixes.add(suffix);
+    return suffix;
   }
 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -73,7 +73,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     public static final String EC2_INSTANCE_TAG_NAMESPACE = "ec2-fleet-plugin";
     public static final String EC2_INSTANCE_CLOUD_NAME_TAG = EC2_INSTANCE_TAG_NAMESPACE + ":cloud-name";
 
-    public static final String DEFAULT_FLEET_CLOUD_ID = "FleetCloud";
+    public static final String BASE_DEFAULT_FLEET_CLOUD_ID = "FleetCloud";
 
     public static final int DEFAULT_CLOUD_STATUS_INTERVAL_SEC = 10;
 
@@ -188,7 +188,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                          final boolean scaleExecutorsByWeight,
                          final Integer cloudStatusIntervalSec,
                          final boolean noDelayProvision) {
-        super(name);
+        super(StringUtils.isNotBlank(name) ? name : CloudNames.generateUnique(BASE_DEFAULT_FLEET_CLOUD_ID));
         init();
         this.credentialsId = credentialsId;
         this.awsCredentialsId = awsCredentialsId;
@@ -1003,7 +1003,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
 
         public String getDefaultCloudName() {
-            return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
+            return CloudNames.generateUnique(BASE_DEFAULT_FLEET_CLOUD_ID);
         }
 
         public Boolean isExistingCloudNameDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -63,7 +63,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
     public static final String EC2_INSTANCE_TAG_NAMESPACE = "ec2-fleet-plugin";
     public static final String EC2_INSTANCE_CLOUD_NAME_TAG = EC2_INSTANCE_TAG_NAMESPACE + ":cloud-name";
 
-    public static final String DEFAULT_FLEET_CLOUD_ID = "FleetCloudLabel";
+    public static final String BASE_DEFAULT_FLEET_CLOUD_ID = "FleetCloudLabel";
 
     public static final int DEFAULT_CLOUD_STATUS_INTERVAL_SEC = 10;
 
@@ -125,7 +125,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                               final Integer cloudStatusIntervalSec,
                               final boolean noDelayProvision,
                               final String ec2KeyPairName) {
-        super(name);
+        super(StringUtils.isNotBlank(name) ? name : CloudNames.generateUnique(BASE_DEFAULT_FLEET_CLOUD_ID));
         init();
         this.awsCredentialsId = awsCredentialsId;
         this.region = region;
@@ -873,7 +873,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
         }
 
         public String getDefaultCloudName() {
-            return CloudNames.generateUnique(DEFAULT_FLEET_CLOUD_ID);
+            return CloudNames.generateUnique(BASE_DEFAULT_FLEET_CLOUD_ID);
         }
 
         public Boolean isExistingCloudNameDuplicated(@QueryParameter final String name) { return CloudNames.isDuplicated(name); }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java
@@ -67,33 +67,71 @@ public class CloudNamesTest {
 
   @Test
   public void generateUnique_noSuffix() {
-    Assert.assertEquals("FleetCloud", CloudNames.generateUnique("FleetCloud"));
+    Assert.assertEquals("UniqueCloud", CloudNames.generateUnique("UniqueCloud"));
   }
 
   @Test
   public void generateUnique_addsSuffixOnlyWhenNeeded() {
-    j.jenkins.clouds.add(new EC2FleetCloud("FleetCloud-1", null, null, null, null, null,
+    j.jenkins.clouds.add(new EC2FleetCloud("UniqueCloud-1", null, null, null, null, null,
             "test-label", null, null, false, false,
             0, 0, 0, 0, 0, true, false,
             "-1", false, 0, 0, false,
             10, false));
 
-    Assert.assertEquals("FleetCloud", CloudNames.generateUnique("FleetCloud"));
+    Assert.assertEquals("UniqueCloud", CloudNames.generateUnique("UniqueCloud"));
   }
 
   @Test
   public void generateUnique_addsSuffixCorrectly() {
-    j.jenkins.clouds.add(new EC2FleetCloud("FleetCloud", null, null, null, null, null,
+    j.jenkins.clouds.add(new EC2FleetCloud("UniqueCloud", null, null, null, null, null,
             "test-label", null, null, false, false,
             0, 0, 0, 0, 0, true, false,
             "-1", false, 0, 0, false,
             10, false));
-    j.jenkins.clouds.add(new EC2FleetCloud("FleetCloud-1", null, null, null, null, null,
+    j.jenkins.clouds.add(new EC2FleetCloud("UniqueCloud-1", null, null, null, null, null,
             "test-label", null, null, false, false,
             0, 0, 0, 0, 0, true, false,
             "-1", false, 0, 0, false,
             10, false));
 
-    Assert.assertEquals("FleetCloud-2", CloudNames.generateUnique("FleetCloud"));
+    String actual = CloudNames.generateUnique("UniqueCloud");
+    Assert.assertTrue(actual.length() == ("UniqueCloud".length() + CloudNames.SUFFIX_LENGTH + 1));
+    Assert.assertTrue(actual.startsWith("UniqueCloud-"));
+  }
+
+  @Test
+  public void generateUnique_emptyStringInConstructor() {
+    EC2FleetCloud fleetCloud = new EC2FleetCloud("", null, null, null, null, null,
+            "test-label", null, null, false, false,
+            0, 0, 0, 0, 0, true, false,
+            "-1", false, 0, 0, false,
+            10, false);
+    EC2FleetLabelCloud fleetLabelCloud = new EC2FleetLabelCloud("", null, null,
+            null, null, new LocalComputerConnector(j), false, false,
+            0, 0, 0, 1, false,
+            false, 0, 0,
+            2, false, null);
+
+    Assert.assertEquals(("FleetCloud".length() + CloudNames.SUFFIX_LENGTH + 1), fleetCloud.name.length());
+    Assert.assertTrue(fleetCloud.name.startsWith(EC2FleetCloud.BASE_DEFAULT_FLEET_CLOUD_ID));
+    Assert.assertEquals(("FleetLabelCloud".length() + CloudNames.SUFFIX_LENGTH + 1), fleetLabelCloud.name.length());
+    Assert.assertTrue(fleetLabelCloud.name.startsWith(EC2FleetLabelCloud.BASE_DEFAULT_FLEET_CLOUD_ID));
+  }
+
+  @Test
+  public void generateUnique_nonEmptyStringInConstructor() {
+    EC2FleetCloud fleetCloud = new EC2FleetCloud("UniqueCloud", null, null, null, null, null,
+            "test-label", null, null, false, false,
+            0, 0, 0, 0, 0, true, false,
+            "-1", false, 0, 0, false,
+            10, false);
+    EC2FleetLabelCloud fleetLabelCloud = new EC2FleetLabelCloud("UniqueLabelCloud", null, null,
+            null, null, new LocalComputerConnector(j), false, false,
+            0, 0, 0, 1, false,
+            false, 0, 0,
+            2, false, null);
+            
+    Assert.assertEquals("UniqueCloud", fleetCloud.name);
+    Assert.assertEquals("UniqueLabelCloud", fleetLabelCloud.name);
   }
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudConfigurationAsCodeTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudConfigurationAsCodeTest.java
@@ -4,10 +4,10 @@ import com.amazon.jenkins.ec2fleet.fleet.EC2Fleet;
 import com.amazon.jenkins.ec2fleet.fleet.EC2Fleets;
 import hudson.plugins.sshslaves.SSHConnector;
 import hudson.plugins.sshslaves.verifiers.NonVerifyingKeyVerificationStrategy;
+import hudson.slaves.Cloud;
 import io.jenkins.plugins.casc.ConfiguratorException;
 import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
 import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
@@ -102,5 +103,17 @@ public class EC2FleetCloudConfigurationAsCodeTest {
 
         SSHConnector sshConnector = (SSHConnector) cloud.getComputerConnector();
         assertEquals(sshConnector.getSshHostKeyVerificationStrategy().getClass(), NonVerifyingKeyVerificationStrategy.class);
+    }
+
+    @Test
+    @ConfiguredWithCode("EC2FleetCloud/empty-name-configuration-as-code.yml")
+    public void configurationWithEmptyName_shouldUseDefault() {
+        assertEquals(jenkinsRule.jenkins.clouds.size(), 3);
+
+        for (EC2FleetCloud cloud : jenkinsRule.jenkins.clouds.getAll(EC2FleetCloud.class)){
+
+            assertTrue(cloud.name.startsWith(EC2FleetCloud.BASE_DEFAULT_FLEET_CLOUD_ID));
+            assertEquals(("FleetCloud".length() + CloudNames.SUFFIX_LENGTH + 1), cloud.name.length());
+        }
     }
 }

--- a/src/test/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/empty-name-configuration-as-code.yml
+++ b/src/test/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/empty-name-configuration-as-code.yml
@@ -1,0 +1,8 @@
+jenkins:
+  clouds:
+    - ec2Fleet:
+        name: ""
+    - ec2Fleet:
+        name: ""
+    - ec2Fleet:
+        name: ""


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Suffix generation now uses a randomly generated string instead of incremental for default cloud name generation through UI or empty strings in CasC configurations.

### Testing done
Altered and added Unit Tests in [EC2CloudNamesTest.java](https://github.com/vineeth-bandi/ec2-fleet-plugin/blob/suffix-generation/src/test/java/com/amazon/jenkins/ec2fleet/CloudNamesTest.java) for new functionality.

Added Unit Test in [EC2FleetCloudConfigurationAsCodeTest.java](https://github.com/vineeth-bandi/ec2-fleet-plugin/blob/suffix-generation/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudConfigurationAsCodeTest.java) for empty strings in CasC.

Tested that both UI and CasC generate default cloud names properly. On creation of new clouds and empty strings in yaml file for UI and CasC, respectively.

Verified functionality of added features in Jenkins version 2.277.2 and version 2.414

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
