### PR TITLE
add getMaxTotalUses

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -313,6 +313,10 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         return minSpareSize;
     }
 
+    public int getMaxTotalUses() {
+        return maxTotalUses;
+    }
+
     public int getNumExecutors() {
         return numExecutors;
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Added the method `getMaxTotalUses` which fixes Issue #397 

### Testing done

Verified that set value for `Max Total Uses` persists through config save and apply on Jenkins version 2.277.2 and 2.414. Previous behavior with lack of getter method was to replace with default value of `-1` every time on Cloud Configuration page.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
