### PR TITLE
Format and remove testing from descriptions in UI

### DIFF
--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/config.jelly
@@ -79,12 +79,12 @@
       <f:textbox />
     </f:entry>
 
-    <f:description>Testing Number of executors per instance</f:description>
+    <f:description>Number of executors per instance</f:description>
     <f:entry title="${%Number of Executors}" field="numExecutors">
       <f:textbox clazz="required positive-number" default="1" />
     </f:entry>
 
-
+    <f:description>Method for scaling number of executors</f:description>
     <f:dropdownDescriptorSelector field="executorScaler" descriptors="${descriptor.getExecutorScalerDescriptors()}" title="Scale Executors"/>
 
     <f:description>How long to keep an idle node. If set to 0, never scale down</f:description>

--- a/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-executorScaler.html
+++ b/src/main/resources/com/amazon/jenkins/ec2fleet/EC2FleetCloud/help-executorScaler.html
@@ -2,13 +2,13 @@
 <h5>No Scaling</h5>
 <p>Doesn't scale. Uses set number of executors</p>
 
-<h5>Scale by node hardware</h5>
+<h5>Scale by Node Hardware</h5>
 <p>Determine number of executors by node hardware: Memory and vCPU count. Specify the quantity of each resource to be
     allocated per executor. The plugin sources the resources of the node and calculates the desired number of executors.
     The lower number of executors calculated will be chosen to prevent over provisioning.
 </p>
 
-<h5>Scale by weight</h5>
+<h5>Scale by Weight</h5>
 
 <p>
     The plugin consumes <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html#spot-instance-weighting">instance


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The word "Testing" was left in a description in the UI and has been removed. Altered the capitalization in a help section to have uniformity.

### Testing done
Ran the plugin and viewed that the UI descriptions had changed
