### PR TITLE
Fix NoProxy configuration

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
@@ -45,7 +45,7 @@ public final class AWSUtils {
             }
 
 
-            if (proxy.address() instanceof InetSocketAddress) {
+            if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
                 InetSocketAddress address = (InetSocketAddress) proxy.address();
                 clientConfiguration.setProxyHost(address.getHostName());
                 clientConfiguration.setProxyPort(address.getPort());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
@@ -11,8 +11,6 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public final class AWSUtils {
 

--- a/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
@@ -2,6 +2,7 @@ package com.amazon.jenkins.ec2fleet.aws;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.retry.PredefinedRetryPolicies;
+import com.google.common.base.Joiner;
 import hudson.ProxyConfiguration;
 import jenkins.model.Jenkins;
 
@@ -47,6 +48,10 @@ public final class AWSUtils {
                 if (null != proxyConfig.getUserName()) {
                     clientConfiguration.setProxyUsername(proxyConfig.getUserName());
                     clientConfiguration.setProxyPassword(proxyConfig.getSecretPassword().getPlainText());
+                }
+                if (null != proxyConfig.getNoProxyHost()) {
+                    String[] noProxyParts = proxyConfig.getNoProxyHost().split("[ \t\n,|]+");
+                    clientConfiguration.setNonProxyHosts(Joiner.on(',').join(noProxyParts));
                 }
             }
         }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
@@ -1,5 +1,6 @@
 package com.amazon.jenkins.ec2fleet.aws;
 
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.google.common.base.Joiner;
@@ -10,6 +11,8 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public final class AWSUtils {
 
@@ -41,7 +44,8 @@ public final class AWSUtils {
                 proxy = proxyConfig.createProxy(endpoint);
             }
 
-            if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
+
+            if (proxy.address() instanceof InetSocketAddress) {
                 InetSocketAddress address = (InetSocketAddress) proxy.address();
                 clientConfiguration.setProxyHost(address.getHostName());
                 clientConfiguration.setProxyPort(address.getPort());
@@ -51,7 +55,7 @@ public final class AWSUtils {
                 }
                 if (null != proxyConfig.getNoProxyHost()) {
                     String[] noProxyParts = proxyConfig.getNoProxyHost().split("[ \t\n,|]+");
-                    clientConfiguration.setNonProxyHosts(Joiner.on(',').join(noProxyParts));
+                    clientConfiguration.setNonProxyHosts(Joiner.on('|').join(noProxyParts));
                 }
             }
         }


### PR DESCRIPTION
Fixes #441

The  `!proxy.equals(Proxy.NO_PROXY)` check does not appear to catch all cases that it should. Explicitly pass the Jenkins No Proxy list through to the client configuration to handle the cases that get past that check.

### Testing done
Tested on our live instance with our No Proxy list and confirmed traffic wasn't being sent to the proxy as expected.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
