### PR TITLE
Resubmitting last unsuccessful build instead of last failed build

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -102,7 +102,7 @@ public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLaun
 
                     final List<Action> actions = new ArrayList<>();
                     if (task instanceof WorkflowJob) {
-                        final WorkflowRun failedBuild = ((WorkflowJob) task).getLastFailedBuild();
+                        final WorkflowRun failedBuild = ((WorkflowJob) task).getLastUnsuccessfulBuild();
                         actions.addAll(failedBuild.getActions(ParametersAction.class));
                     }
                     if (executable instanceof Actionable) {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -189,7 +189,7 @@ public class EC2FleetAutoResubmitComputerLauncherTest {
     @Test
     public void taskCompleted_should_resubmit_task_with_failed_build_actions() {
         when(subTask1.getOwnerTask()).thenReturn(workflowJob);
-        when(workflowJob.getLastFailedBuild()).thenReturn(workflowRun);
+        when(workflowJob.getLastUnsuccessfulBuild()).thenReturn(workflowRun);
         when(workflowRun.getActions(any())).thenReturn((Collections.singletonList(action1)));
         when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/ec2-fleet-plugin/issues/443

When an agent gets disconnected (AWS interruption) the job is set to aborted. 
Currently the job that gets resubmitted is the last failed job, which is not the job that was running on the agent that got disconnected, leading to the wrong parameters being used with the resubmitted job. 

This fixes the issue by using `getLastUnsuccessfulBuild` to get the last job that ran before the agent went down.

### Testing done

Unit testing with `mvn test` and locally

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
