### PR TITLE
Fix wrong value shown in build executor status for builds left

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -55,9 +55,9 @@ public class EC2FleetNodeComputer extends SlaveComputer {
     public String getDisplayName() {
         final EC2FleetNode node = getNode();
         if(node != null) {
-            final int totalUses = node.getMaxTotalUses();
-            if(totalUses != -1) {
-                return String.format("%s Builds left: %d ", node.getDisplayName(), totalUses);
+            final int usesRemaining = node.getUsesRemaining();
+            if(usesRemaining >= 0) {
+                return String.format("%s Builds left: %d ", node.getDisplayName(), usesRemaining);
             }
             return node.getDisplayName();
         }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputerTest.java
@@ -41,7 +41,7 @@ public class EC2FleetNodeComputerTest {
     @Test
     public void getDisplayName_returns_node_display_name_for_default_maxTotalUses() {
         when(agent.getDisplayName()).thenReturn("a n");
-        when(agent.getMaxTotalUses()).thenReturn(-1);
+        when(agent.getUsesRemaining()).thenReturn(-1);
 
         EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(agent));
         doReturn(agent).when(computer).getNode();
@@ -52,7 +52,7 @@ public class EC2FleetNodeComputerTest {
     @Test
     public void getDisplayName_returns_builds_left_for_non_default_maxTotalUses() {
         when(agent.getDisplayName()).thenReturn("a n");
-        when(agent.getMaxTotalUses()).thenReturn(1);
+        when(agent.getUsesRemaining()).thenReturn(1);
 
         EC2FleetNodeComputer computer = spy(new EC2FleetNodeComputer(agent));
         doReturn(agent).when(computer).getNode();


### PR DESCRIPTION
Fixes #457

The value of max total uses is no longer decremented. This change was introduce with #375
Instead the _usesRemaining_ contains the builds left value.
This is used to be shown in the build executor status.

### Testing done
Test on a local test instance.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

