### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,16 +76,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>apache-client</artifactId>
-      <version>2.31.63</version>
-    </dependency>
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>netty-nio-client</artifactId>
-      <version>2.31.63</version>
-    </dependency>
-    <dependency>
       <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
       <artifactId>aws-java-sdk2-core</artifactId>
     </dependency>
@@ -100,11 +90,6 @@
     <dependency>
       <groupId>io.jenkins.plugins.aws-java-sdk2</groupId>
       <artifactId>aws-java-sdk2-cloudformation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.5.14</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
The Apache HTTP Client is provided by https://plugins.jenkins.io/aws-java-sdk2-core/ and the Netty one by https://plugins.jenkins.io/aws-java-sdk2-netty-nio-client/ (which doesn't seem to be used by this plugin).