### PR TITLE
Create fleet stats endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <packaging>hpi</packaging>
 
   <properties>
-    <revision>4.1.1</revision>
+    <revision>4.2.0</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.492</jenkins.baseline>

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApi.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApi.java
@@ -1,0 +1,53 @@
+package com.amazon.jenkins.ec2fleet;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.Extension;
+import hudson.model.RootAction;
+import hudson.slaves.Cloud;
+import jenkins.model.Jenkins;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.*;
+
+@Extension
+public class EC2FleetStatsApi implements RootAction {
+
+    @Override
+    public String getIconFileName() {
+        return null; // Hide from UI
+    }
+
+    @Override
+    public String getDisplayName() {
+        return null; // Hide from UI
+    }
+
+    @Override
+    public String getUrlName() {
+        return "api/ec2-fleets/json";
+    }
+
+    public void doIndex(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+        List<Map<String, Object>> statsList = new ArrayList<>();
+        for (Cloud cloud : Jenkins.get().clouds) {
+            if (cloud instanceof EC2FleetCloud) {
+                EC2FleetCloud fleetCloud = (EC2FleetCloud) cloud;
+                FleetStateStats stats = fleetCloud.getStats();
+                if (stats != null) {
+                    Map<String, Object> data = new HashMap<>();
+                    data.put("fleet", fleetCloud.getFleet());
+                    data.put("state", stats.getState().getDetailed());
+                    data.put("label", fleetCloud.getLabelString());
+                    data.put("numActive", stats.getNumActive());
+                    data.put("numDesired", stats.getNumDesired());
+                    statsList.add(data);
+                }
+            }
+        }
+        rsp.setContentType("application/json");
+        new ObjectMapper().writeValue(rsp.getWriter(), statsList);
+    }
+}

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApi.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApi.java
@@ -27,10 +27,10 @@ public class EC2FleetStatsApi implements RootAction {
 
     @Override
     public String getUrlName() {
-        return "api/ec2-fleets/json";
+        return "ec2-fleet";
     }
 
-    public void doIndex(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
+    public void doStats(HttpServletRequest req, HttpServletResponse rsp) throws IOException, ServletException {
         List<Map<String, Object>> statsList = new ArrayList<>();
         for (Cloud cloud : Jenkins.get().clouds) {
             if (cloud instanceof EC2FleetCloud) {

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
@@ -1,3 +1,5 @@
+package com.amazon.jenkins.ec2fleet;
+
 import com.amazon.jenkins.ec2fleet.EC2FleetCloud;
 import com.amazon.jenkins.ec2fleet.FleetStateStats;
 import hudson.slaves.Cloud;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
@@ -1,4 +1,3 @@
-java
 package com.amazon.jenkins.ec2fleet;
 
 import com.amazon.jenkins.ec2fleet.FleetStateStats;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
@@ -5,9 +5,9 @@ import com.amazon.jenkins.ec2fleet.FleetStateStats;
 import hudson.slaves.Cloud;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.Rule;
 import org.mockito.Mockito;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.JenkinsRuleExtension;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -18,10 +18,9 @@ import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@ExtendWith(JenkinsRuleExtension.class)
 public class EC2FleetStatsApiTest {
 
-    @JenkinsRule
+    @Rule
     public JenkinsRule jenkinsRule = new JenkinsRule();
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
@@ -1,13 +1,13 @@
+java
 package com.amazon.jenkins.ec2fleet;
 
-import com.amazon.jenkins.ec2fleet.EC2FleetCloud;
 import com.amazon.jenkins.ec2fleet.FleetStateStats;
-import hudson.slaves.Cloud;
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.Rule;
-import org.mockito.Mockito;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+import org.mockito.Mockito;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -18,29 +18,30 @@ import java.util.HashSet;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class EC2FleetStatsApiTest {
+@WithJenkins
+class EC2FleetStatsApiTest {
 
-    @Rule
-    public JenkinsRule jenkinsRule = new JenkinsRule();
+    private JenkinsRule j;
+
+    @BeforeEach
+    void before(JenkinsRule rule) {
+        j = rule;
+    }
 
     @Test
-    public void testFleetStatsApiEndpointReturnsExpectedJson() throws Exception {
-        // Mock FleetStateStats
+    void testFleetStatsApiEndpointReturnsExpectedJson() throws Exception {
         FleetStateStats.State state = new FleetStateStats.State(true, false, "active");
         FleetStateStats stats = new FleetStateStats("fleet-1", 2, state,
                 new HashSet<>(Arrays.asList("i-1", "i-2")), Collections.emptyMap());
 
-        // Mock EC2FleetCloud
         EC2FleetCloud cloud = Mockito.mock(EC2FleetCloud.class);
         Mockito.when(cloud.getStats()).thenReturn(stats);
         Mockito.when(cloud.getFleet()).thenReturn("fleet-1");
         Mockito.when(cloud.getLabelString()).thenReturn("label-1");
 
-        // Add mock cloud to Jenkins
-        jenkinsRule.jenkins.clouds.add(cloud);
+        j.jenkins.clouds.add(cloud);
 
-        // Make HTTP request to the endpoint
-        String url = jenkinsRule.getURL() + "ec2-fleet/stats";
+        String url = j.getURL() + "ec2-fleet/stats";
         try (InputStream is = new URL(url).openStream()) {
             String json = new String(is.readAllBytes(), StandardCharsets.UTF_8);
             assertTrue(json.contains("\"fleet\":\"fleet-1\""));

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetStatsApiTest.java
@@ -1,0 +1,51 @@
+import com.amazon.jenkins.ec2fleet.EC2FleetCloud;
+import com.amazon.jenkins.ec2fleet.FleetStateStats;
+import hudson.slaves.Cloud;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRuleExtension;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(JenkinsRuleExtension.class)
+public class EC2FleetStatsApiTest {
+
+    @JenkinsRule
+    public JenkinsRule jenkinsRule = new JenkinsRule();
+
+    @Test
+    public void testFleetStatsApiEndpointReturnsExpectedJson() throws Exception {
+        // Mock FleetStateStats
+        FleetStateStats.State state = new FleetStateStats.State(true, false, "active");
+        FleetStateStats stats = new FleetStateStats("fleet-1", 2, state,
+                new HashSet<>(Arrays.asList("i-1", "i-2")), Collections.emptyMap());
+
+        // Mock EC2FleetCloud
+        EC2FleetCloud cloud = Mockito.mock(EC2FleetCloud.class);
+        Mockito.when(cloud.getStats()).thenReturn(stats);
+        Mockito.when(cloud.getFleet()).thenReturn("fleet-1");
+        Mockito.when(cloud.getLabelString()).thenReturn("label-1");
+
+        // Add mock cloud to Jenkins
+        jenkinsRule.jenkins.clouds.add(cloud);
+
+        // Make HTTP request to the endpoint
+        String url = jenkinsRule.getURL() + "ec2-fleet/stats";
+        try (InputStream is = new URL(url).openStream()) {
+            String json = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(json.contains("\"fleet\":\"fleet-1\""));
+            assertTrue(json.contains("\"state\":\"active\""));
+            assertTrue(json.contains("\"label\":\"label-1\""));
+            assertTrue(json.contains("\"numActive\":2"));
+        }
+    }
+}


### PR DESCRIPTION
Implements endpoint to retrieve JSON response of fleet stat information.

GET request to `https://<jenkins-url>/ec2-fleet/stats` will return payload like
`[
  {
    "numActive": 0,
    "fleet": "fleet-1",
    "numDesired": 0,
    "state": "active",
    "label": "linux"
  }
]`

Resolves #445 

### Testing done
Added test to verify JSON is returned with expected values.
Installed on test Jenkins cluster and verified endpoint functioned correctly.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
