### PR TITLE
Use getHostString so when proxy is set to IP address there is no reve…

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/aws/AWSUtils.java
@@ -64,7 +64,7 @@ public final class AWSUtils {
             Proxy proxy = proxyConfig.createProxy(host);
             if (!proxy.equals(Proxy.NO_PROXY) && proxy.address() instanceof InetSocketAddress) {
                 InetSocketAddress address = (InetSocketAddress) proxy.address();
-                String proxyHost = address.getHostName();
+                String proxyHost = address.getHostString();
                 int proxyPort = address.getPort();
                 String proxyScheme = "http"; // Jenkins ProxyConfiguration does not expose scheme, default to http
                 URI proxyUri = URI.create(proxyScheme + "://" + proxyHost + ":" + proxyPort);


### PR DESCRIPTION
…rse lookup done.

Small change to make sure that when the proxy is set to a IP address no reverse lookup is done.  currenly with InetSocketAddress.getHostName() there is a reverse lookup done. When the proxy is set to a IP address I would expect to also connect to that IP address.
For documentation see: https://docs.oracle.com/javase/8/docs/api/java/net/InetSocketAddress.html#getAddress--
fixes #505 

### Testing done
All tests still pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
