### PR TITLE
Build resubmit fix

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -102,8 +102,8 @@ public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLaun
 
                     final List<Action> actions = new ArrayList<>();
                     if (task instanceof WorkflowJob) {
-                        final WorkflowRun lastBuild = ((WorkflowJob) task).getLastBuild();
-                        actions.addAll(lastBuild.getActions(ParametersAction.class));
+                        final WorkflowRun LastUnsuccessfulBuild = ((WorkflowJob) task).getLastUnsuccessfulBuild();
+                        actions.addAll(LastUnsuccessfulBuild.getActions(ParametersAction.class));
                     }
                     if (executable instanceof Actionable) {
                         actions.addAll(((Actionable) executable).getAllActions());

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncherTest.java
@@ -203,7 +203,7 @@ class EC2FleetAutoResubmitComputerLauncherTest {
     @Test
     void taskCompleted_should_resubmit_task_with_build_actions() {
         when(subTask1.getOwnerTask()).thenReturn(workflowJob);
-        when(workflowJob.getLastBuild()).thenReturn(workflowRun);
+        when(workflowJob.getLastUnsuccessfulBuild()).thenReturn(workflowRun);
         when(workflowRun.getActions(any())).thenReturn((Collections.singletonList(action1)));
         when(computer.getExecutors()).thenReturn(Arrays.asList(executor1));
         new EC2FleetAutoResubmitComputerLauncher(baseComputerLauncher)


### PR DESCRIPTION
Resubmit of a aborted build when spot instance was interrupted did not work correctly when there was not yet a failed build for the job. 
When a spot instance gets interupted the running build get interupted and should be resubmitted. the code currently uses  getLastFailedBuild() which will return null when there was not a failed build for the job yet, and when there is a failed job it is not necessarily the last one that was running when the node was interrupted, a aborted build does not have the state failed but unsuccesfull
In this PR this I changed it to getLastBuild() which gets the build that was running when the node was interrupted
https://javadoc.jenkins.io/plugin/workflow-job/org/jenkinsci/plugins/workflow/job/WorkflowJob.html#getLastBuild()
Error you could get before: 
`java.lang.NullPointerException: Cannot invoke "org.jenkinsci.plugins.workflow.job.WorkflowRun.getActions(java.lang.Class)" because "failedBuild" is null`


### Testing done
I have updated the test to reflect the change, other test succeed.
Tested by interrupting a aws node while the first build for a job was running and it was succesfully resubmitted, also tested other scenarios and build was resubmitted in all of them


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
