### PR TITLE
Look at the current build for resubmit instead of the previous

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetAutoResubmitComputerLauncher.java
@@ -102,8 +102,17 @@ public class EC2FleetAutoResubmitComputerLauncher extends DelegatingComputerLaun
 
                     final List<Action> actions = new ArrayList<>();
                     if (task instanceof WorkflowJob) {
-                        final WorkflowRun lastUnsuccessfulBuild = ((WorkflowJob) task).getLastUnsuccessfulBuild();
-                        actions.addAll(lastUnsuccessfulBuild.getActions(ParametersAction.class));
+                        // Try to get the current running build first (which would be from the executable)
+                        WorkflowRun currentBuild = null;
+                        if (executable instanceof WorkflowRun) {
+                            currentBuild = (WorkflowRun) executable;
+                        } else {
+                            // Fallback to getting the last build (most recent)
+                            currentBuild = ((WorkflowJob) task).getLastBuild();
+                        }
+                        if (currentBuild != null) {
+                            actions.addAll(currentBuild.getActions(ParametersAction.class));
+                        }
                     }
                     if (executable instanceof Actionable) {
                         actions.addAll(((Actionable) executable).getAllActions());


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

What seems to be happening here is that the afterDisconnect is running before the build is actually put into the aborted state, so getLastFailedBuild or getLastUnsuccessfulBuild is actually grabbing the previous one instead of the current one. We can fall back to getLastBuild if needed which will get the latest if there is only one build running, though that may result in some undesired results if multiple builds are running at once.

Fixes #443 

### Testing done
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Tested on a test instance using AWS FIS to trigger spot terminations, verified parameters from the correct job was being used in the resubmit.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
