### PR TITLE
ASG warm pool support

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ Add an inline policy to the IAM user or EC2 instance role to allow it to use EC2
       "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "autoscaling:UpdateAutoScalingGroup"
+        "autoscaling:UpdateAutoScalingGroup",
+        "autoscaling:SetInstanceProtection"
       ],
       "Resource": "*"
     },

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Add an inline policy to the IAM user or EC2 instance role to allow it to use EC2
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:UpdateAutoScalingGroup",
-        "autoscaling:SetInstanceProtection"
+        "autoscaling:SetInstanceProtection",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
       ],
       "Resource": "*"
     },

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Add an inline policy to the IAM user or EC2 instance role to allow it to use EC2
       "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeWarmPool",
         "autoscaling:UpdateAutoScalingGroup",
         "autoscaling:SetInstanceProtection",
         "autoscaling:TerminateInstanceInAutoScalingGroup"

--- a/README.md
+++ b/README.md
@@ -199,6 +199,27 @@ if there are enough tasks waiting in the build queue and scale down idle nodes a
 
 You can use the History tab in the AWS console to view the scaling history.
 
+### Scaling down an Auto Scaling Group with a warm pool
+
+By default, when the plugin scales down an Auto Scaling Group it terminates the idle instance directly
+via `TerminateInstanceInAutoScalingGroup`. This is intentional: relying on the ASG's own scale-in process
+to eventually remove the instance can lag significantly in high-volume environments, so the plugin asks
+AWS to take immediate action instead. This is the same behavior as before warm pool support was added, and
+it is what you get unless your ASG has a
+[warm pool](https://docs.aws.amazon.com/autoscaling/ec2/userguide/ec2-auto-scaling-warm-pools.html) configured
+with an [instance reuse policy](https://docs.aws.amazon.com/autoscaling/ec2/userguide/warm-pool-instance-reuse-policy.html)
+that reuses instances on scale-in (`ReuseOnScaleIn: true`).
+
+When such a warm pool is detected, scaling down instead removes the instance's scale-in protection and lets
+the ASG itself take over, moving the instance into the warm pool instead of terminating it. This lets a
+future build reuse an already-provisioned, cache-warm instance rather than waiting for a brand-new one to
+launch. Instances that reached `maxTotalUses` are always terminated directly regardless of the warm pool
+configuration, since a worn-out instance must never be handed back for reuse.
+
+This check is done via `autoscaling:DescribeWarmPool`, which the IAM policy above already grants; no extra
+configuration is needed to opt in or out — the plugin decides automatically based on how the ASG itself is
+set up.
+
 ## Preconfigure Agent
 
 Sometimes you need to prepare an agent (an EC2 instance) before Jenkins can use it.

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -615,14 +615,18 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 }
             });
             if(EC2Fleets.get(fleet).isAutoScalingGroup()){
-                fine("Terminating instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
-                ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).terminateInstances(awsCredentialsId, region, endpoint, currentInstanceIdsToTerminate.keySet());
+                // For ASGs, we remove scale-in protection from instances and let the ASG terminate them
+                // naturally when the desired capacity is reduced (which happened in the modify() call above).
+                fine("Removing scale-in protection from instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
+                ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).removeScaleInProtection(
+                        awsCredentialsId, region, endpoint, fleet, currentInstanceIdsToTerminate.keySet());
+                info("Removed scale-in protection from instances (ASG will terminate them): %s", currentInstanceIdsToTerminate);
             }
             else {
                 fine("Terminating instances: %s", currentInstanceIdsToTerminate.keySet());
                 Registry.getEc2Api().terminateInstances(ec2, currentInstanceIdsToTerminate.keySet());
+                info("Terminated instances: %s", currentInstanceIdsToTerminate);
             }
-            info("Terminated instances: %s", currentInstanceIdsToTerminate);
         }
 
         fine("Fleet instances: %s", updatedState.getInstances());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -615,12 +615,35 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 }
             });
             if(EC2Fleets.get(fleet).isAutoScalingGroup()){
-                // For ASGs, we remove scale-in protection from instances and let the ASG terminate them
-                // naturally when the desired capacity is reduced (which happened in the modify() call above).
-                fine("Removing scale-in protection from instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
-                ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).removeScaleInProtection(
-                        awsCredentialsId, region, endpoint, fleet, currentInstanceIdsToTerminate.keySet());
-                info("Removed scale-in protection from instances (ASG will terminate them): %s", currentInstanceIdsToTerminate);
+                // For ASGs, separate instances by termination reason:
+                // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them (desired capacity unchanged)
+                // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally
+                final Set<String> instancesToTerminateDirectly = new HashSet<>();
+                final Set<String> instancesToRemoveProtection = new HashSet<>();
+
+                for (Map.Entry<String, EC2AgentTerminationReason> entry : currentInstanceIdsToTerminate.entrySet()) {
+                    if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                        instancesToTerminateDirectly.add(entry.getKey());
+                    } else {
+                        instancesToRemoveProtection.add(entry.getKey());
+                    }
+                }
+
+                if (!instancesToTerminateDirectly.isEmpty()) {
+                    // Terminate instances that reached maxTotalUses - ASG will replace them
+                    fine("Terminating instances in AutoScalingGroup (maxTotalUses exhausted): %s", instancesToTerminateDirectly);
+                    ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).terminateInstances(
+                            awsCredentialsId, region, endpoint, fleet, instancesToTerminateDirectly);
+                    info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
+                }
+
+                if (!instancesToRemoveProtection.isEmpty()) {
+                    // For scale-down, remove protection and let ASG terminate naturally
+                    fine("Removing scale-in protection from instances in AutoScalingGroup: %s", instancesToRemoveProtection);
+                    ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).removeScaleInProtection(
+                            awsCredentialsId, region, endpoint, fleet, instancesToRemoveProtection);
+                    info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
+                }
             }
             else {
                 fine("Terminating instances: %s", currentInstanceIdsToTerminate.keySet());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -615,14 +615,22 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 }
             });
             if(EC2Fleets.get(fleet).isAutoScalingGroup()){
+                final AutoScalingGroupFleet asgFleet = (AutoScalingGroupFleet) EC2Fleets.get(fleet);
+                // Only reuse the ASG's natural scale-in (remove protection, let ASG move instance to
+                // warm pool) when a warm pool with an instance reuse policy is actually configured.
+                // Otherwise keep the pre-warm-pool behavior of terminating instances directly.
+                final boolean hasWarmPoolWithInstanceReuse =
+                        asgFleet.hasWarmPoolWithInstanceReuse(awsCredentialsId, region, endpoint, fleet);
+
                 // For ASGs, separate instances by termination reason:
                 // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them (desired capacity unchanged)
-                // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally
+                // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally,
+                //   but only when a warm pool with instance reuse is configured
                 final Set<String> instancesToTerminateDirectly = new HashSet<>();
                 final Set<String> instancesToRemoveProtection = new HashSet<>();
 
                 for (Map.Entry<String, EC2AgentTerminationReason> entry : currentInstanceIdsToTerminate.entrySet()) {
-                    if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                    if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED || !hasWarmPoolWithInstanceReuse) {
                         instancesToTerminateDirectly.add(entry.getKey());
                     } else {
                         instancesToRemoveProtection.add(entry.getKey());
@@ -632,7 +640,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 if (!instancesToTerminateDirectly.isEmpty()) {
                     // Terminate instances that reached maxTotalUses - ASG will replace them
                     fine("Terminating instances in AutoScalingGroup (maxTotalUses exhausted): %s", instancesToTerminateDirectly);
-                    ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).terminateInstances(
+                    asgFleet.terminateInstances(
                             awsCredentialsId, region, endpoint, fleet, instancesToTerminateDirectly);
                     info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
                 }
@@ -640,7 +648,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                 if (!instancesToRemoveProtection.isEmpty()) {
                     // For scale-down, remove protection and let ASG terminate naturally
                     fine("Removing scale-in protection from instances in AutoScalingGroup: %s", instancesToRemoveProtection);
-                    ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).removeScaleInProtection(
+                    asgFleet.removeScaleInProtection(
                             awsCredentialsId, region, endpoint, fleet, instancesToRemoveProtection);
                     info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
                 }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -678,48 +678,15 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
         if (currentInstanceIdsToTerminate.size() > 0) {
             if (EC2Fleets.get(fleet).isAutoScalingGroup()) {
-                final AutoScalingGroupFleet asgFleet = (AutoScalingGroupFleet) EC2Fleets.get(fleet);
-                // Only reuse the ASG's natural scale-in (remove protection, let ASG move instance to
-                // warm pool) when a warm pool with an instance reuse policy is actually configured.
-                // Otherwise keep the pre-warm-pool behavior of terminating instances directly.
-                final boolean hasWarmPoolWithInstanceReuse =
-                        asgFleet.hasWarmPoolWithInstanceReuse(awsCredentialsId, region, endpoint, fleet);
-
-                // For ASGs, separate instances by termination reason:
-                // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them (desired capacity unchanged)
-                // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally,
-                //   but only when a warm pool with instance reuse is configured
-                final Set<String> instancesToTerminateDirectly = new HashSet<>();
-                final Set<String> instancesToRemoveProtection = new HashSet<>();
-
-                for (Map.Entry<String, EC2AgentTerminationReason> entry : currentInstanceIdsToTerminate.entrySet()) {
-                    if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED || !hasWarmPoolWithInstanceReuse) {
-                        instancesToTerminateDirectly.add(entry.getKey());
-                    } else {
-                        instancesToRemoveProtection.add(entry.getKey());
-                    }
-                }
-
-                if (!instancesToTerminateDirectly.isEmpty()) {
-                    // Terminate instances that reached maxTotalUses - ASG will replace them
-                    fine("Terminating instances in AutoScalingGroup (maxTotalUses exhausted): %s", instancesToTerminateDirectly);
-                    asgFleet.terminateInstances(
-                            awsCredentialsId, region, endpoint, fleet, instancesToTerminateDirectly);
-                    info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
-                }
-
-                if (!instancesToRemoveProtection.isEmpty()) {
-                    // For scale-down, remove protection and let ASG terminate naturally
-                    fine("Removing scale-in protection from instances in AutoScalingGroup: %s", instancesToRemoveProtection);
-                    asgFleet.removeScaleInProtection(
-                            awsCredentialsId, region, endpoint, fleet, instancesToRemoveProtection);
-                    info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
-                }
+                // Let the ASG decide between reusing instances (warm pool) and terminating them.
+                fine("Terminating instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
+                ((AutoScalingGroupFleet) EC2Fleets.get(fleet))
+                        .terminateInstances(getAwsCredentialsId(), region, endpoint, fleet, currentInstanceIdsToTerminate);
             } else {
                 fine("Terminating instances: %s", currentInstanceIdsToTerminate.keySet());
                 Registry.getEc2Api().terminateInstances(ec2, currentInstanceIdsToTerminate.keySet());
-                info("Terminated instances: %s", currentInstanceIdsToTerminate);
             }
+            info("Terminated instances: %s", currentInstanceIdsToTerminate);
         }
 
         fine("Fleet instances: %s", updatedState.getInstances());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -678,10 +678,16 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
 
         if (currentInstanceIdsToTerminate.size() > 0) {
             if (EC2Fleets.get(fleet).isAutoScalingGroup()) {
-                // Let the ASG decide between reusing instances (warm pool) and terminating them.
-                fine("Terminating instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
-                ((AutoScalingGroupFleet) EC2Fleets.get(fleet))
-                        .terminateInstances(getAwsCredentialsId(), region, endpoint, fleet, currentInstanceIdsToTerminate);
+                final AutoScalingGroupFleet asgFleet = (AutoScalingGroupFleet) EC2Fleets.get(fleet);
+                if (asgFleet.hasWarmPoolWithInstanceReuse(awsCredentialsId, region, endpoint, fleet)) {
+                    // Warm pool with instance reuse: hand instances back to the ASG so it can reuse them.
+                    fine("Scaling down AutoScalingGroup with warm pool: %s", currentInstanceIdsToTerminate.keySet());
+                    asgFleet.scaleDownWithWarmPool(awsCredentialsId, region, endpoint, fleet, currentInstanceIdsToTerminate);
+                } else {
+                    // No warm pool: terminate instances directly so the ASG replaces them.
+                    fine("Terminating instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
+                    asgFleet.terminateInstances(awsCredentialsId, region, endpoint, currentInstanceIdsToTerminate.keySet());
+                }
             } else {
                 fine("Terminating instances: %s", currentInstanceIdsToTerminate.keySet());
                 Registry.getEc2Api().terminateInstances(ec2, currentInstanceIdsToTerminate.keySet());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -4,6 +4,8 @@ import com.amazon.jenkins.ec2fleet.aws.AwsPermissionChecker;
 import com.amazon.jenkins.ec2fleet.aws.CloudFormationApi;
 import com.amazon.jenkins.ec2fleet.aws.EC2Api;
 import com.amazon.jenkins.ec2fleet.aws.RegionHelper;
+import com.amazon.jenkins.ec2fleet.fleet.AutoScalingGroupFleet;
+import com.amazon.jenkins.ec2fleet.fleet.EC2Fleet;
 import com.amazon.jenkins.ec2fleet.fleet.EC2Fleets;
 import com.amazon.jenkins.ec2fleet.fleet.EC2SpotFleet;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
@@ -440,8 +442,32 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             });
             info("Delete terminating nodes from Jenkins %s", instanceIdsToRemove);
 
-            Registry.getEc2Api().terminateInstances(ec2, instanceIdsToRemove.keySet());
-            info("Instances %s were terminated with result", instanceIdsToRemove);
+            // Group instances by fleet and handle ASGs differently
+            final Set<String> ec2InstancesToTerminate = new HashSet<>();
+            for (State state : states.values()) {
+                if (state.instanceIdsToTerminate.isEmpty()) {
+                    continue;
+                }
+                final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
+                if (fleet.isAutoScalingGroup()) {
+                    // For ASGs, remove scale-in protection and let the ASG terminate instances
+                    fine("Removing scale-in protection from instances in AutoScalingGroup %s: %s",
+                            state.fleetId, state.instanceIdsToTerminate.keySet());
+                    ((AutoScalingGroupFleet) fleet).removeScaleInProtection(
+                            getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate.keySet());
+                    info("Removed scale-in protection from instances (ASG will terminate them): %s", state.instanceIdsToTerminate);
+                } else {
+                    // For non-ASG fleets, collect instances to terminate via EC2 API
+                    ec2InstancesToTerminate.addAll(state.instanceIdsToTerminate.keySet());
+                }
+            }
+
+            // Terminate non-ASG instances via EC2 API
+            if (!ec2InstancesToTerminate.isEmpty()) {
+                fine("Terminating instances via EC2 API: %s", ec2InstancesToTerminate);
+                Registry.getEc2Api().terminateInstances(ec2, ec2InstancesToTerminate);
+                info("Instances %s were terminated", ec2InstancesToTerminate);
+            }
         }
 
         for (final Map.Entry<String, State> entry : states.entrySet()) {

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -450,12 +450,35 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 }
                 final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
                 if (fleet.isAutoScalingGroup()) {
-                    // For ASGs, remove scale-in protection and let the ASG terminate instances
-                    fine("Removing scale-in protection from instances in AutoScalingGroup %s: %s",
-                            state.fleetId, state.instanceIdsToTerminate.keySet());
-                    ((AutoScalingGroupFleet) fleet).removeScaleInProtection(
-                            getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate.keySet());
-                    info("Removed scale-in protection from instances (ASG will terminate them): %s", state.instanceIdsToTerminate);
+                    // For ASGs, separate instances by termination reason:
+                    // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them
+                    // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally
+                    final Set<String> instancesToTerminateDirectly = new HashSet<>();
+                    final Set<String> instancesToRemoveProtection = new HashSet<>();
+
+                    for (Map.Entry<String, EC2AgentTerminationReason> entry : state.instanceIdsToTerminate.entrySet()) {
+                        if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                            instancesToTerminateDirectly.add(entry.getKey());
+                        } else {
+                            instancesToRemoveProtection.add(entry.getKey());
+                        }
+                    }
+
+                    if (!instancesToTerminateDirectly.isEmpty()) {
+                        fine("Terminating instances in AutoScalingGroup %s (maxTotalUses exhausted): %s",
+                                state.fleetId, instancesToTerminateDirectly);
+                        ((AutoScalingGroupFleet) fleet).terminateInstances(
+                                getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToTerminateDirectly);
+                        info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
+                    }
+
+                    if (!instancesToRemoveProtection.isEmpty()) {
+                        fine("Removing scale-in protection from instances in AutoScalingGroup %s: %s",
+                                state.fleetId, instancesToRemoveProtection);
+                        ((AutoScalingGroupFleet) fleet).removeScaleInProtection(
+                                getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToRemoveProtection);
+                        info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
+                    }
                 } else {
                     // For non-ASG fleets, collect instances to terminate via EC2 API
                     ec2InstancesToTerminate.addAll(state.instanceIdsToTerminate.keySet());

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -466,28 +466,28 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             });
             info("Delete terminating nodes from Jenkins %s", instanceIdsToRemove);
 
-            // ASGs decide between reusing instances (warm pool) and terminating them; other fleets
-            // are terminated directly via the EC2 API.
-            final Set<String> ec2InstancesToTerminate = new HashSet<>();
-            for (State state : states.values()) {
+            // Instances that belong to an ASG with a warm pool are handed back to their ASG for reuse
+            // and removed from instanceIdsToRemove, so they are excluded from the direct EC2 termination
+            // below. Everything else is terminated as before.
+            final Map<String, Boolean> warmPoolByFleetId = new HashMap<>();
+            for (final State state : states.values()) {
                 if (state.instanceIdsToTerminate.isEmpty()) {
                     continue;
                 }
                 final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
-                if (fleet.isAutoScalingGroup()) {
-                    fine("Terminating instances in AutoScalingGroup %s: %s",
-                            state.fleetId, state.instanceIdsToTerminate.keySet());
-                    ((AutoScalingGroupFleet) fleet).terminateInstances(
-                            getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate);
-                } else {
-                    ec2InstancesToTerminate.addAll(state.instanceIdsToTerminate.keySet());
+                // Look up the warm pool at most once per fleet.
+                if (!warmPoolByFleetId.computeIfAbsent(state.fleetId, id -> useWarmPool(fleet, id))) {
+                    continue;
                 }
+                fine("Scaling down AutoScalingGroup %s with warm pool: %s",
+                        state.fleetId, state.instanceIdsToTerminate.keySet());
+                ((AutoScalingGroupFleet) fleet).scaleDownWithWarmPool(
+                        getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate);
+                instanceIdsToRemove.keySet().removeAll(state.instanceIdsToTerminate.keySet());
             }
 
-            if (!ec2InstancesToTerminate.isEmpty()) {
-                Registry.getEc2Api().terminateInstances(ec2, ec2InstancesToTerminate);
-                info("Instances %s were terminated", ec2InstancesToTerminate);
-            }
+            Registry.getEc2Api().terminateInstances(ec2, instanceIdsToRemove.keySet());
+            info("Instances %s were terminated with result", instanceIdsToRemove);
         }
 
         for (final Map.Entry<String, State> entry : states.entrySet()) {
@@ -595,6 +595,17 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 });
             }
         }
+    }
+
+    /**
+     * Returns {@code true} when the fleet is an Auto Scaling Group configured with a warm pool that
+     * reuses instances on scale-in. Only then are instances handed back to the ASG for reuse instead
+     * of being terminated directly.
+     */
+    private boolean useWarmPool(final EC2Fleet fleet, final String fleetId) {
+        return fleet.isAutoScalingGroup()
+                && ((AutoScalingGroupFleet) fleet).hasWarmPoolWithInstanceReuse(
+                        getAwsCredentialsId(), region, endpoint, fleetId);
     }
 
     @Override

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -450,14 +450,22 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 }
                 final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
                 if (fleet.isAutoScalingGroup()) {
+                    final AutoScalingGroupFleet asgFleet = (AutoScalingGroupFleet) fleet;
+                    // Only reuse the ASG's natural scale-in (remove protection, let ASG move instance to
+                    // warm pool) when a warm pool with an instance reuse policy is actually configured.
+                    // Otherwise keep the pre-warm-pool behavior of terminating instances directly.
+                    final boolean hasWarmPoolWithInstanceReuse = asgFleet.hasWarmPoolWithInstanceReuse(
+                            getAwsCredentialsId(), region, endpoint, state.fleetId);
+
                     // For ASGs, separate instances by termination reason:
                     // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them
-                    // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally
+                    // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally,
+                    //   but only when a warm pool with instance reuse is configured
                     final Set<String> instancesToTerminateDirectly = new HashSet<>();
                     final Set<String> instancesToRemoveProtection = new HashSet<>();
 
                     for (Map.Entry<String, EC2AgentTerminationReason> entry : state.instanceIdsToTerminate.entrySet()) {
-                        if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                        if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED || !hasWarmPoolWithInstanceReuse) {
                             instancesToTerminateDirectly.add(entry.getKey());
                         } else {
                             instancesToRemoveProtection.add(entry.getKey());
@@ -467,7 +475,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                     if (!instancesToTerminateDirectly.isEmpty()) {
                         fine("Terminating instances in AutoScalingGroup %s (maxTotalUses exhausted): %s",
                                 state.fleetId, instancesToTerminateDirectly);
-                        ((AutoScalingGroupFleet) fleet).terminateInstances(
+                        asgFleet.terminateInstances(
                                 getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToTerminateDirectly);
                         info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
                     }
@@ -475,7 +483,7 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                     if (!instancesToRemoveProtection.isEmpty()) {
                         fine("Removing scale-in protection from instances in AutoScalingGroup %s: %s",
                                 state.fleetId, instancesToRemoveProtection);
-                        ((AutoScalingGroupFleet) fleet).removeScaleInProtection(
+                        asgFleet.removeScaleInProtection(
                                 getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToRemoveProtection);
                         info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
                     }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -466,7 +466,8 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
             });
             info("Delete terminating nodes from Jenkins %s", instanceIdsToRemove);
 
-            // Group instances by fleet and handle ASGs differently
+            // ASGs decide between reusing instances (warm pool) and terminating them; other fleets
+            // are terminated directly via the EC2 API.
             final Set<String> ec2InstancesToTerminate = new HashSet<>();
             for (State state : states.values()) {
                 if (state.instanceIdsToTerminate.isEmpty()) {
@@ -474,52 +475,16 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 }
                 final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
                 if (fleet.isAutoScalingGroup()) {
-                    final AutoScalingGroupFleet asgFleet = (AutoScalingGroupFleet) fleet;
-                    // Only reuse the ASG's natural scale-in (remove protection, let ASG move instance to
-                    // warm pool) when a warm pool with an instance reuse policy is actually configured.
-                    // Otherwise keep the pre-warm-pool behavior of terminating instances directly.
-                    final boolean hasWarmPoolWithInstanceReuse = asgFleet.hasWarmPoolWithInstanceReuse(
-                            getAwsCredentialsId(), region, endpoint, state.fleetId);
-
-                    // For ASGs, separate instances by termination reason:
-                    // - MAX_TOTAL_USES_EXHAUSTED: terminate directly so ASG replaces them
-                    // - Other reasons (scale-down): remove scale-in protection and let ASG terminate naturally,
-                    //   but only when a warm pool with instance reuse is configured
-                    final Set<String> instancesToTerminateDirectly = new HashSet<>();
-                    final Set<String> instancesToRemoveProtection = new HashSet<>();
-
-                    for (Map.Entry<String, EC2AgentTerminationReason> entry : state.instanceIdsToTerminate.entrySet()) {
-                        if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED || !hasWarmPoolWithInstanceReuse) {
-                            instancesToTerminateDirectly.add(entry.getKey());
-                        } else {
-                            instancesToRemoveProtection.add(entry.getKey());
-                        }
-                    }
-
-                    if (!instancesToTerminateDirectly.isEmpty()) {
-                        fine("Terminating instances in AutoScalingGroup %s (maxTotalUses exhausted): %s",
-                                state.fleetId, instancesToTerminateDirectly);
-                        asgFleet.terminateInstances(
-                                getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToTerminateDirectly);
-                        info("Terminated instances (maxTotalUses exhausted, ASG will replace): %s", instancesToTerminateDirectly);
-                    }
-
-                    if (!instancesToRemoveProtection.isEmpty()) {
-                        fine("Removing scale-in protection from instances in AutoScalingGroup %s: %s",
-                                state.fleetId, instancesToRemoveProtection);
-                        asgFleet.removeScaleInProtection(
-                                getAwsCredentialsId(), region, endpoint, state.fleetId, instancesToRemoveProtection);
-                        info("Removed scale-in protection from instances (ASG will terminate them): %s", instancesToRemoveProtection);
-                    }
+                    fine("Terminating instances in AutoScalingGroup %s: %s",
+                            state.fleetId, state.instanceIdsToTerminate.keySet());
+                    ((AutoScalingGroupFleet) fleet).terminateInstances(
+                            getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate);
                 } else {
-                    // For non-ASG fleets, collect instances to terminate via EC2 API
                     ec2InstancesToTerminate.addAll(state.instanceIdsToTerminate.keySet());
                 }
             }
 
-            // Terminate non-ASG instances via EC2 API
             if (!ec2InstancesToTerminate.isEmpty()) {
-                fine("Terminating instances via EC2 API: %s", ec2InstancesToTerminate);
                 Registry.getEc2Api().terminateInstances(ec2, ec2InstancesToTerminate);
                 info("Instances %s were terminated", ec2InstancesToTerminate);
             }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetLabelCloud.java
@@ -476,14 +476,18 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 }
                 final EC2Fleet fleet = EC2Fleets.get(state.fleetId);
                 // Look up the warm pool at most once per fleet.
-                if (!warmPoolByFleetId.computeIfAbsent(state.fleetId, id -> useWarmPool(fleet, id))) {
-                    continue;
+                final boolean useWarmPool = warmPoolByFleetId.computeIfAbsent(state.fleetId, id ->
+                        fleet.isAutoScalingGroup()
+                                && ((AutoScalingGroupFleet) fleet).hasWarmPoolWithInstanceReuse(
+                                        getAwsCredentialsId(), region, endpoint, id));
+                if (useWarmPool) {
+                    // Warm pool with instance reuse confirmed: hand instances back to the ASG so it can reuse them.
+                    fine("Scaling down AutoScalingGroup %s with warm pool: %s",
+                            state.fleetId, state.instanceIdsToTerminate.keySet());
+                    ((AutoScalingGroupFleet) fleet).scaleDownWithWarmPool(
+                            getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate);
+                    instanceIdsToRemove.keySet().removeAll(state.instanceIdsToTerminate.keySet());
                 }
-                fine("Scaling down AutoScalingGroup %s with warm pool: %s",
-                        state.fleetId, state.instanceIdsToTerminate.keySet());
-                ((AutoScalingGroupFleet) fleet).scaleDownWithWarmPool(
-                        getAwsCredentialsId(), region, endpoint, state.fleetId, state.instanceIdsToTerminate);
-                instanceIdsToRemove.keySet().removeAll(state.instanceIdsToTerminate.keySet());
             }
 
             Registry.getEc2Api().terminateInstances(ec2, instanceIdsToRemove.keySet());
@@ -595,17 +599,6 @@ public class EC2FleetLabelCloud extends AbstractEC2FleetCloud {
                 });
             }
         }
-    }
-
-    /**
-     * Returns {@code true} when the fleet is an Auto Scaling Group configured with a warm pool that
-     * reuses instances on scale-in. Only then are instances handed back to the ASG for reuse instead
-     * of being terminated directly.
-     */
-    private boolean useWarmPool(final EC2Fleet fleet, final String fleetId) {
-        return fleet.isAutoScalingGroup()
-                && ((AutoScalingGroupFleet) fleet).hasWarmPoolWithInstanceReuse(
-                        getAwsCredentialsId(), region, endpoint, fleetId);
     }
 
     @Override

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -127,23 +127,54 @@ public class AutoScalingGroupFleet implements EC2Fleet {
         return clientBuilder.build();
     }
 
-    public void terminateInstances(final String awsCredentialsId, final String regionName, final String endpoint, final Collection<String> instanceIds) {
+    /**
+     * Removes scale-in protection from the specified instances, allowing the ASG to terminate them
+     * when the desired capacity is reduced (which happens via the modify() call before this method is invoked).
+     *
+     * This approach lets the ASG handle instance termination naturally rather than the plugin
+     * explicitly calling terminateInstanceInAutoScalingGroup().
+     */
+    public void removeScaleInProtection(final String awsCredentialsId, final String regionName,
+                                         final String endpoint, final String autoScalingGroupName,
+                                         final Collection<String> instanceIds) {
+        if (instanceIds == null || instanceIds.isEmpty()) {
+            return;
+        }
+
         final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
 
-        for(String instanceId : instanceIds) {
-            if (StringUtils.isBlank(instanceId)) {
-                throw new IllegalArgumentException("Instance ID cannot be null or empty");
-            }
-            try{
-                // Attempt to terminate the instance in the Auto Scaling group first
-                client.terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
-                        .instanceId(instanceId)
-                        .shouldDecrementDesiredCapacity(false)
-                        .build());
-            } catch (Exception e) {
-                LOGGER.warning(String.format("Failed to terminate instance %s in Auto Scaling group: %s", instanceId, e.getMessage()));
-            }
+        // Filter out blank instance IDs
+        final List<String> validInstanceIds = instanceIds.stream()
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toList());
+
+        if (validInstanceIds.isEmpty()) {
+            return;
         }
+
+        try {
+            // Remove scale-in protection from all instances in a single API call
+            client.setInstanceProtection(SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(autoScalingGroupName)
+                    .instanceIds(validInstanceIds)
+                    .protectedFromScaleIn(false)
+                    .build());
+            LOGGER.info(String.format("Removed scale-in protection from instances: %s", validInstanceIds));
+        } catch (Exception e) {
+            LOGGER.warning(String.format("Failed to remove scale-in protection from instances %s: %s",
+                    validInstanceIds, e.getMessage()));
+        }
+    }
+
+    /**
+     * @deprecated Use {@link #removeScaleInProtection(String, String, String, String, Collection)} instead.
+     * This method is kept for backwards compatibility but now delegates to removeScaleInProtection.
+     */
+    @Deprecated
+    public void terminateInstances(final String awsCredentialsId, final String regionName,
+                                   final String endpoint, final Collection<String> instanceIds) {
+        LOGGER.warning("terminateInstances() is deprecated. The ASG name is required to remove scale-in protection. " +
+                "This call will be ignored. Please update to use removeScaleInProtection().");
     }
 
     // TODO: merge with EC2Api#getEndpoint

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -167,14 +167,56 @@ public class AutoScalingGroupFleet implements EC2Fleet {
     }
 
     /**
-     * @deprecated Use {@link #removeScaleInProtection(String, String, String, String, Collection)} instead.
-     * This method is kept for backwards compatibility but now delegates to removeScaleInProtection.
+     * Terminates instances in the Auto Scaling Group directly.
+     * Use this for cases like maxTotalUses exhausted where the instance should be replaced
+     * (desired capacity stays the same, but the specific instance needs to be terminated).
+     *
+     * For scale-down scenarios where desired capacity is reduced, use
+     * {@link #removeScaleInProtection(String, String, String, String, Collection)} instead.
+     */
+    public void terminateInstances(final String awsCredentialsId, final String regionName,
+                                   final String endpoint, final String autoScalingGroupName,
+                                   final Collection<String> instanceIds) {
+        if (instanceIds == null || instanceIds.isEmpty()) {
+            return;
+        }
+
+        final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
+
+        for (String instanceId : instanceIds) {
+            if (StringUtils.isBlank(instanceId)) {
+                continue;
+            }
+            try {
+                // First remove scale-in protection so termination can proceed
+                client.setInstanceProtection(SetInstanceProtectionRequest.builder()
+                        .autoScalingGroupName(autoScalingGroupName)
+                        .instanceIds(instanceId)
+                        .protectedFromScaleIn(false)
+                        .build());
+
+                // Then terminate the instance - ASG will launch a replacement
+                client.terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                        .instanceId(instanceId)
+                        .shouldDecrementDesiredCapacity(false)
+                        .build());
+                LOGGER.info(String.format("Terminated instance %s in Auto Scaling group %s", instanceId, autoScalingGroupName));
+            } catch (Exception e) {
+                LOGGER.warning(String.format("Failed to terminate instance %s in Auto Scaling group %s: %s",
+                        instanceId, autoScalingGroupName, e.getMessage()));
+            }
+        }
+    }
+
+    /**
+     * @deprecated Use {@link #terminateInstances(String, String, String, String, Collection)} instead.
+     * This method is kept for backwards compatibility but the ASG name is now required.
      */
     @Deprecated
     public void terminateInstances(final String awsCredentialsId, final String regionName,
                                    final String endpoint, final Collection<String> instanceIds) {
-        LOGGER.warning("terminateInstances() is deprecated. The ASG name is required to remove scale-in protection. " +
-                "This call will be ignored. Please update to use removeScaleInProtection().");
+        LOGGER.warning("terminateInstances() without ASG name is deprecated and will be ignored. " +
+                "Please update to use terminateInstances() with ASG name parameter.");
     }
 
     // TODO: merge with EC2Api#getEndpoint

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -128,6 +128,36 @@ public class AutoScalingGroupFleet implements EC2Fleet {
     }
 
     /**
+     * Checks whether this Auto Scaling Group has a warm pool configured with an instance reuse
+     * policy that reuses instances on scale-in (i.e. {@code ReuseOnScaleIn=true}).
+     *
+     * Only in that case is it safe to remove scale-in protection and let the ASG take the instance
+     * naturally, since the instance will be moved to the warm pool rather than terminated outright.
+     * Otherwise the plugin falls back to explicitly terminating the instance via
+     * {@link #terminateInstances(String, String, String, String, Collection)}, matching the
+     * pre-warm-pool behavior (AWS recommends calling terminateInstanceInAutoScalingGroup directly
+     * to avoid scaling lag in high volume environments).
+     */
+    public boolean hasWarmPoolWithInstanceReuse(final String awsCredentialsId, final String regionName,
+                                                 final String endpoint, final String autoScalingGroupName) {
+        final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
+        try {
+            final DescribeWarmPoolResponse response = client.describeWarmPool(DescribeWarmPoolRequest.builder()
+                    .autoScalingGroupName(autoScalingGroupName)
+                    .build());
+            final WarmPoolConfiguration warmPoolConfiguration = response.warmPoolConfiguration();
+            return warmPoolConfiguration != null
+                    && warmPoolConfiguration.instanceReusePolicy() != null
+                    && Boolean.TRUE.equals(warmPoolConfiguration.instanceReusePolicy().reuseOnScaleIn());
+        } catch (Exception e) {
+            LOGGER.warning(String.format(
+                    "Failed to describe warm pool for Auto Scaling group %s, assuming no warm pool: %s",
+                    autoScalingGroupName, e.getMessage()));
+            return false;
+        }
+    }
+
+    /**
      * Removes scale-in protection from the specified instances, allowing the ASG to terminate them
      * when the desired capacity is reduced (which happens via the modify() call before this method is invoked).
      *

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -128,70 +128,37 @@ public class AutoScalingGroupFleet implements EC2Fleet {
         return clientBuilder.build();
     }
 
-    /**
-     * Terminates the given instances of this Auto Scaling Group.
-     *
-     * <p>When the ASG has a warm pool with instance reuse ({@code ReuseOnScaleIn=true}), instances
-     * being scaled down are simply handed back to the ASG by removing their scale-in protection, so
-     * the ASG moves them to the warm pool for reuse (faster, cache-warm builds) instead of
-     * terminating them. Instances that must not be reused (e.g. {@code MAX_TOTAL_USES_EXHAUSTED}), or
-     * any instance when no such warm pool is configured, are terminated directly so the ASG replaces
-     * them with a fresh instance.
-     */
-    public void terminateInstances(final String awsCredentialsId, final String regionName, final String endpoint,
-                                   final String autoScalingGroupName,
-                                   final Map<String, EC2AgentTerminationReason> instances) {
-        if (instances == null || instances.isEmpty()) {
-            return;
-        }
-
+    public void terminateInstances(final String awsCredentialsId, final String regionName, final String endpoint, final Collection<String> instanceIds) {
         final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
 
-        // The warm pool is only queried when there is actually something to terminate.
-        final boolean reuseFromWarmPool = hasWarmPoolWithInstanceReuse(client, autoScalingGroupName);
-
-        final List<String> instancesForWarmPool = new ArrayList<>();
-        final List<String> instancesToTerminate = new ArrayList<>();
-        for (final Map.Entry<String, EC2AgentTerminationReason> entry : instances.entrySet()) {
-            if (StringUtils.isBlank(entry.getKey())) {
-                continue;
+        for(String instanceId : instanceIds) {
+            if (StringUtils.isBlank(instanceId)) {
+                throw new IllegalArgumentException("Instance ID cannot be null or empty");
             }
-            if (reuseFromWarmPool && entry.getValue() != EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
-                instancesForWarmPool.add(entry.getKey());
-            } else {
-                instancesToTerminate.add(entry.getKey());
-            }
-        }
-
-        // Scale-down: drop protection in one call and let the ASG move the instances to the warm pool.
-        if (!instancesForWarmPool.isEmpty()) {
-            try {
-                setScaleInProtection(client, autoScalingGroupName, instancesForWarmPool);
-                LOGGER.info(String.format("Removed scale-in protection so ASG %s can move instances to warm pool: %s",
-                        autoScalingGroupName, instancesForWarmPool));
-            } catch (Exception e) {
-                LOGGER.warning(String.format("Failed to remove scale-in protection from instances %s: %s",
-                        instancesForWarmPool, e.getMessage()));
-            }
-        }
-
-        // Terminate directly so the ASG launches a fresh replacement.
-        for (final String instanceId : instancesToTerminate) {
-            try {
-                setScaleInProtection(client, autoScalingGroupName, Collections.singletonList(instanceId));
+            try{
+                // Attempt to terminate the instance in the Auto Scaling group first
                 client.terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
                         .instanceId(instanceId)
                         .shouldDecrementDesiredCapacity(false)
                         .build());
-                LOGGER.info(String.format("Terminated instance %s in Auto Scaling group %s", instanceId, autoScalingGroupName));
             } catch (Exception e) {
-                LOGGER.warning(String.format("Failed to terminate instance %s in Auto Scaling group %s: %s",
-                        instanceId, autoScalingGroupName, e.getMessage()));
+                LOGGER.warning(String.format("Failed to terminate instance %s in Auto Scaling group: %s", instanceId, e.getMessage()));
             }
         }
     }
 
-    private boolean hasWarmPoolWithInstanceReuse(final AutoScalingClient client, final String autoScalingGroupName) {
+    /**
+     * Returns {@code true} when this Auto Scaling Group has a warm pool configured with an instance
+     * reuse policy that reuses instances on scale-in ({@code ReuseOnScaleIn=true}).
+     *
+     * <p>Only in that case is it safe to scale the ASG down by removing scale-in protection and
+     * letting the ASG take the instance, since it is moved to the warm pool for reuse rather than
+     * terminated outright. Any failure to look up the warm pool is treated as "no warm pool" so the
+     * caller falls back to the pre-warm-pool behavior of terminating instances directly.
+     */
+    public boolean hasWarmPoolWithInstanceReuse(final String awsCredentialsId, final String regionName,
+                                                 final String endpoint, final String autoScalingGroupName) {
+        final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
         try {
             final WarmPoolConfiguration warmPool = client.describeWarmPool(DescribeWarmPoolRequest.builder()
                     .autoScalingGroupName(autoScalingGroupName)
@@ -207,13 +174,59 @@ public class AutoScalingGroupFleet implements EC2Fleet {
         }
     }
 
-    private void setScaleInProtection(final AutoScalingClient client, final String autoScalingGroupName,
-                                      final Collection<String> instanceIds) {
-        client.setInstanceProtection(SetInstanceProtectionRequest.builder()
-                .autoScalingGroupName(autoScalingGroupName)
-                .instanceIds(instanceIds)
-                .protectedFromScaleIn(false)
-                .build());
+    /**
+     * Scales the Auto Scaling Group down when it has a warm pool with instance reuse.
+     *
+     * <p>Scale-down instances are handed back to the ASG by removing their scale-in protection, so
+     * the ASG moves them to the warm pool for reuse (faster, cache-warm builds) instead of
+     * terminating them. Instances that must not be reused (e.g. {@code MAX_TOTAL_USES_EXHAUSTED}) are
+     * terminated directly via {@link #terminateInstances(String, String, String, Collection)} so the
+     * ASG replaces them with a fresh instance.
+     *
+     * <p>Should only be called when {@link #hasWarmPoolWithInstanceReuse(String, String, String, String)}
+     * returned {@code true}; otherwise use {@link #terminateInstances(String, String, String, Collection)}.
+     */
+    public void scaleDownWithWarmPool(final String awsCredentialsId, final String regionName, final String endpoint,
+                                      final String autoScalingGroupName,
+                                      final Map<String, EC2AgentTerminationReason> instances) {
+        if (instances == null || instances.isEmpty()) {
+            return;
+        }
+
+        final List<String> instancesForWarmPool = new ArrayList<>();
+        final List<String> instancesToTerminate = new ArrayList<>();
+        for (final Map.Entry<String, EC2AgentTerminationReason> entry : instances.entrySet()) {
+            if (StringUtils.isBlank(entry.getKey())) {
+                continue;
+            }
+            if (entry.getValue() == EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                instancesToTerminate.add(entry.getKey());
+            } else {
+                instancesForWarmPool.add(entry.getKey());
+            }
+        }
+
+        // Scale-down: drop protection in one call and let the ASG move the instances to the warm pool.
+        if (!instancesForWarmPool.isEmpty()) {
+            final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
+            try {
+                client.setInstanceProtection(SetInstanceProtectionRequest.builder()
+                        .autoScalingGroupName(autoScalingGroupName)
+                        .instanceIds(instancesForWarmPool)
+                        .protectedFromScaleIn(false)
+                        .build());
+                LOGGER.info(String.format("Removed scale-in protection so ASG %s can move instances to warm pool: %s",
+                        autoScalingGroupName, instancesForWarmPool));
+            } catch (Exception e) {
+                LOGGER.warning(String.format("Failed to remove scale-in protection from instances %s: %s",
+                        instancesForWarmPool, e.getMessage()));
+            }
+        }
+
+        // Worn-out instances must never be reused: terminate them so the ASG replaces them.
+        if (!instancesToTerminate.isEmpty()) {
+            terminateInstances(awsCredentialsId, regionName, endpoint, instancesToTerminate);
+        }
     }
 
     // TODO: merge with EC2Api#getEndpoint

--- a/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleet.java
@@ -1,5 +1,6 @@
 package com.amazon.jenkins.ec2fleet.fleet;
 
+import com.amazon.jenkins.ec2fleet.EC2AgentTerminationReason;
 import com.amazon.jenkins.ec2fleet.FleetStateStats;
 import com.amazon.jenkins.ec2fleet.aws.AWSUtils;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
@@ -128,104 +129,56 @@ public class AutoScalingGroupFleet implements EC2Fleet {
     }
 
     /**
-     * Checks whether this Auto Scaling Group has a warm pool configured with an instance reuse
-     * policy that reuses instances on scale-in (i.e. {@code ReuseOnScaleIn=true}).
+     * Terminates the given instances of this Auto Scaling Group.
      *
-     * Only in that case is it safe to remove scale-in protection and let the ASG take the instance
-     * naturally, since the instance will be moved to the warm pool rather than terminated outright.
-     * Otherwise the plugin falls back to explicitly terminating the instance via
-     * {@link #terminateInstances(String, String, String, String, Collection)}, matching the
-     * pre-warm-pool behavior (AWS recommends calling terminateInstanceInAutoScalingGroup directly
-     * to avoid scaling lag in high volume environments).
+     * <p>When the ASG has a warm pool with instance reuse ({@code ReuseOnScaleIn=true}), instances
+     * being scaled down are simply handed back to the ASG by removing their scale-in protection, so
+     * the ASG moves them to the warm pool for reuse (faster, cache-warm builds) instead of
+     * terminating them. Instances that must not be reused (e.g. {@code MAX_TOTAL_USES_EXHAUSTED}), or
+     * any instance when no such warm pool is configured, are terminated directly so the ASG replaces
+     * them with a fresh instance.
      */
-    public boolean hasWarmPoolWithInstanceReuse(final String awsCredentialsId, final String regionName,
-                                                 final String endpoint, final String autoScalingGroupName) {
-        final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
-        try {
-            final DescribeWarmPoolResponse response = client.describeWarmPool(DescribeWarmPoolRequest.builder()
-                    .autoScalingGroupName(autoScalingGroupName)
-                    .build());
-            final WarmPoolConfiguration warmPoolConfiguration = response.warmPoolConfiguration();
-            return warmPoolConfiguration != null
-                    && warmPoolConfiguration.instanceReusePolicy() != null
-                    && Boolean.TRUE.equals(warmPoolConfiguration.instanceReusePolicy().reuseOnScaleIn());
-        } catch (Exception e) {
-            LOGGER.warning(String.format(
-                    "Failed to describe warm pool for Auto Scaling group %s, assuming no warm pool: %s",
-                    autoScalingGroupName, e.getMessage()));
-            return false;
-        }
-    }
-
-    /**
-     * Removes scale-in protection from the specified instances, allowing the ASG to terminate them
-     * when the desired capacity is reduced (which happens via the modify() call before this method is invoked).
-     *
-     * This approach lets the ASG handle instance termination naturally rather than the plugin
-     * explicitly calling terminateInstanceInAutoScalingGroup().
-     */
-    public void removeScaleInProtection(final String awsCredentialsId, final String regionName,
-                                         final String endpoint, final String autoScalingGroupName,
-                                         final Collection<String> instanceIds) {
-        if (instanceIds == null || instanceIds.isEmpty()) {
+    public void terminateInstances(final String awsCredentialsId, final String regionName, final String endpoint,
+                                   final String autoScalingGroupName,
+                                   final Map<String, EC2AgentTerminationReason> instances) {
+        if (instances == null || instances.isEmpty()) {
             return;
         }
 
         final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
 
-        // Filter out blank instance IDs
-        final List<String> validInstanceIds = instanceIds.stream()
-                .filter(StringUtils::isNotBlank)
-                .collect(Collectors.toList());
+        // The warm pool is only queried when there is actually something to terminate.
+        final boolean reuseFromWarmPool = hasWarmPoolWithInstanceReuse(client, autoScalingGroupName);
 
-        if (validInstanceIds.isEmpty()) {
-            return;
-        }
-
-        try {
-            // Remove scale-in protection from all instances in a single API call
-            client.setInstanceProtection(SetInstanceProtectionRequest.builder()
-                    .autoScalingGroupName(autoScalingGroupName)
-                    .instanceIds(validInstanceIds)
-                    .protectedFromScaleIn(false)
-                    .build());
-            LOGGER.info(String.format("Removed scale-in protection from instances: %s", validInstanceIds));
-        } catch (Exception e) {
-            LOGGER.warning(String.format("Failed to remove scale-in protection from instances %s: %s",
-                    validInstanceIds, e.getMessage()));
-        }
-    }
-
-    /**
-     * Terminates instances in the Auto Scaling Group directly.
-     * Use this for cases like maxTotalUses exhausted where the instance should be replaced
-     * (desired capacity stays the same, but the specific instance needs to be terminated).
-     *
-     * For scale-down scenarios where desired capacity is reduced, use
-     * {@link #removeScaleInProtection(String, String, String, String, Collection)} instead.
-     */
-    public void terminateInstances(final String awsCredentialsId, final String regionName,
-                                   final String endpoint, final String autoScalingGroupName,
-                                   final Collection<String> instanceIds) {
-        if (instanceIds == null || instanceIds.isEmpty()) {
-            return;
-        }
-
-        final AutoScalingClient client = createClient(awsCredentialsId, regionName, endpoint);
-
-        for (String instanceId : instanceIds) {
-            if (StringUtils.isBlank(instanceId)) {
+        final List<String> instancesForWarmPool = new ArrayList<>();
+        final List<String> instancesToTerminate = new ArrayList<>();
+        for (final Map.Entry<String, EC2AgentTerminationReason> entry : instances.entrySet()) {
+            if (StringUtils.isBlank(entry.getKey())) {
                 continue;
             }
-            try {
-                // First remove scale-in protection so termination can proceed
-                client.setInstanceProtection(SetInstanceProtectionRequest.builder()
-                        .autoScalingGroupName(autoScalingGroupName)
-                        .instanceIds(instanceId)
-                        .protectedFromScaleIn(false)
-                        .build());
+            if (reuseFromWarmPool && entry.getValue() != EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED) {
+                instancesForWarmPool.add(entry.getKey());
+            } else {
+                instancesToTerminate.add(entry.getKey());
+            }
+        }
 
-                // Then terminate the instance - ASG will launch a replacement
+        // Scale-down: drop protection in one call and let the ASG move the instances to the warm pool.
+        if (!instancesForWarmPool.isEmpty()) {
+            try {
+                setScaleInProtection(client, autoScalingGroupName, instancesForWarmPool);
+                LOGGER.info(String.format("Removed scale-in protection so ASG %s can move instances to warm pool: %s",
+                        autoScalingGroupName, instancesForWarmPool));
+            } catch (Exception e) {
+                LOGGER.warning(String.format("Failed to remove scale-in protection from instances %s: %s",
+                        instancesForWarmPool, e.getMessage()));
+            }
+        }
+
+        // Terminate directly so the ASG launches a fresh replacement.
+        for (final String instanceId : instancesToTerminate) {
+            try {
+                setScaleInProtection(client, autoScalingGroupName, Collections.singletonList(instanceId));
                 client.terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
                         .instanceId(instanceId)
                         .shouldDecrementDesiredCapacity(false)
@@ -238,15 +191,29 @@ public class AutoScalingGroupFleet implements EC2Fleet {
         }
     }
 
-    /**
-     * @deprecated Use {@link #terminateInstances(String, String, String, String, Collection)} instead.
-     * This method is kept for backwards compatibility but the ASG name is now required.
-     */
-    @Deprecated
-    public void terminateInstances(final String awsCredentialsId, final String regionName,
-                                   final String endpoint, final Collection<String> instanceIds) {
-        LOGGER.warning("terminateInstances() without ASG name is deprecated and will be ignored. " +
-                "Please update to use terminateInstances() with ASG name parameter.");
+    private boolean hasWarmPoolWithInstanceReuse(final AutoScalingClient client, final String autoScalingGroupName) {
+        try {
+            final WarmPoolConfiguration warmPool = client.describeWarmPool(DescribeWarmPoolRequest.builder()
+                    .autoScalingGroupName(autoScalingGroupName)
+                    .build()).warmPoolConfiguration();
+            return warmPool != null
+                    && warmPool.instanceReusePolicy() != null
+                    && Boolean.TRUE.equals(warmPool.instanceReusePolicy().reuseOnScaleIn());
+        } catch (Exception e) {
+            LOGGER.warning(String.format(
+                    "Failed to describe warm pool for Auto Scaling group %s, assuming no warm pool: %s",
+                    autoScalingGroupName, e.getMessage()));
+            return false;
+        }
+    }
+
+    private void setScaleInProtection(final AutoScalingClient client, final String autoScalingGroupName,
+                                      final Collection<String> instanceIds) {
+        client.setInstanceProtection(SetInstanceProtectionRequest.builder()
+                .autoScalingGroupName(autoScalingGroupName)
+                .instanceIds(instanceIds)
+                .protectedFromScaleIn(false)
+                .build());
     }
 
     // TODO: merge with EC2Api#getEndpoint

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -2155,7 +2155,7 @@ class EC2FleetCloudTest {
     }
 
     @Test
-    void update_shouldTerminateInstancesInAutoScalingGroup() throws IllegalAccessException, NoSuchFieldException {
+    void update_shouldRemoveScaleInProtectionInAutoScalingGroup() throws IllegalAccessException, NoSuchFieldException {
         // Arrange
         final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
         when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
@@ -2180,8 +2180,9 @@ class EC2FleetCloudTest {
         // Act
         fleetCloud.update();
 
-        // Assert
-        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq(Collections.singleton("i-0")));
+        // Assert - verify removeScaleInProtection is called instead of terminateInstances
+        // for ASGs, the ASG will terminate the instance when desired capacity is reduced
+        verify(autoScalingGroupFleet).removeScaleInProtection(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -2155,7 +2155,7 @@ class EC2FleetCloudTest {
     }
 
     @Test
-    void update_shouldRemoveScaleInProtectionInAutoScalingGroup() throws IllegalAccessException, NoSuchFieldException {
+    void update_shouldRemoveScaleInProtectionInAutoScalingGroupForScaleDown() throws IllegalAccessException, NoSuchFieldException {
         // Arrange
         final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
         when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
@@ -2169,7 +2169,39 @@ class EC2FleetCloudTest {
                 null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
                 0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
 
-        // Set up instanceIdsToTerminate
+        // Set up instanceIdsToTerminate with IDLE_FOR_TOO_LONG (scale-down reason)
+        HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
+        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+        fleetCloud.setStats(stats);
+        Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
+        field.setAccessible(true);
+        field.set(fleetCloud, toTerminate);
+
+        // Act
+        fleetCloud.update();
+
+        // Assert - verify removeScaleInProtection is called for scale-down reasons
+        // ASG will terminate the instance when desired capacity is reduced
+        verify(autoScalingGroupFleet).removeScaleInProtection(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
+        verify(autoScalingGroupFleet, never()).terminateInstances(anyString(), any(), any(), anyString(), any());
+    }
+
+    @Test
+    void update_shouldTerminateInstancesInAutoScalingGroupForMaxTotalUsesExhausted() throws IllegalAccessException, NoSuchFieldException {
+        // Arrange
+        final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
+        when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
+        when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
+
+        final FleetStateStats stats = new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
+                Collections.singleton("i-0"), Collections.emptyMap());
+        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
+                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
+
+        // Set up instanceIdsToTerminate with MAX_TOTAL_USES_EXHAUSTED
         HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
         toTerminate.put("i-0", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED);
         fleetCloud.setStats(stats);
@@ -2180,9 +2212,10 @@ class EC2FleetCloudTest {
         // Act
         fleetCloud.update();
 
-        // Assert - verify removeScaleInProtection is called instead of terminateInstances
-        // for ASGs, the ASG will terminate the instance when desired capacity is reduced
-        verify(autoScalingGroupFleet).removeScaleInProtection(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
+        // Assert - verify terminateInstances is called for MAX_TOTAL_USES_EXHAUSTED
+        // Instance should be terminated directly so ASG replaces it
+        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
+        verify(autoScalingGroupFleet, never()).removeScaleInProtection(anyString(), any(), any(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -2160,6 +2160,7 @@ class EC2FleetCloudTest {
         final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
         when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
         when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
+        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(true);
 
         final FleetStateStats stats = new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
                 Collections.singleton("i-0"), Collections.emptyMap());
@@ -2181,9 +2182,43 @@ class EC2FleetCloudTest {
         fleetCloud.update();
 
         // Assert - verify removeScaleInProtection is called for scale-down reasons
-        // ASG will terminate the instance when desired capacity is reduced
+        // when a warm pool with instance reuse is configured; ASG will move the instance
+        // to the warm pool when desired capacity is reduced
         verify(autoScalingGroupFleet).removeScaleInProtection(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
         verify(autoScalingGroupFleet, never()).terminateInstances(anyString(), any(), any(), anyString(), any());
+    }
+
+    @Test
+    void update_shouldTerminateInstancesInAutoScalingGroupForScaleDownWithoutWarmPool() throws IllegalAccessException, NoSuchFieldException {
+        // Arrange
+        final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
+        when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
+        when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
+        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(false);
+
+        final FleetStateStats stats = new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
+                Collections.singleton("i-0"), Collections.emptyMap());
+        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
+                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
+
+        // Set up instanceIdsToTerminate with IDLE_FOR_TOO_LONG (scale-down reason)
+        HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
+        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+        fleetCloud.setStats(stats);
+        Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
+        field.setAccessible(true);
+        field.set(fleetCloud, toTerminate);
+
+        // Act
+        fleetCloud.update();
+
+        // Assert - without a warm pool with instance reuse, scale-down falls back to
+        // terminating the instance directly (pre-warm-pool behavior)
+        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
+        verify(autoScalingGroupFleet, never()).removeScaleInProtection(anyString(), any(), any(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
@@ -3673,130 +3674,34 @@ class EC2FleetCloudTest {
     }
 
     @Test
-    void update_shouldRemoveScaleInProtectionInAutoScalingGroupForScaleDown() throws IllegalAccessException, NoSuchFieldException {
-        // Arrange
-        final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
-        when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
-        when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
-        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(true);
-
-        final FleetStateStats stats = new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
-                Collections.singleton("i-0"), Collections.emptyMap());
-        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
-
-        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
-                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
-                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
-
-        // Set up instanceIdsToTerminate with IDLE_FOR_TOO_LONG (scale-down reason)
-        HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
-        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
-        fleetCloud.setStats(stats);
-        Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
-        field.setAccessible(true);
-        field.set(fleetCloud, toTerminate);
-
-        // Act
-        fleetCloud.update();
-
-        // Assert - verify removeScaleInProtection is called for scale-down reasons
-        // when a warm pool with instance reuse is configured; ASG will move the instance
-        // to the warm pool when desired capacity is reduced
-        verify(autoScalingGroupFleet).removeScaleInProtection(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
-        verify(autoScalingGroupFleet, never()).terminateInstances(anyString(), any(), any(), anyString(), any());
-    }
-
-    @Test
-    void update_shouldTerminateInstancesInAutoScalingGroupForScaleDownWithoutWarmPool() throws IllegalAccessException, NoSuchFieldException {
-        // Arrange
-        final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
-        when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
-        when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
-        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(false);
-
-        final FleetStateStats stats = new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
-                Collections.singleton("i-0"), Collections.emptyMap());
-        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
-
-        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
-                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
-                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
-
-        // Set up instanceIdsToTerminate with IDLE_FOR_TOO_LONG (scale-down reason)
-        HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
-        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
-        fleetCloud.setStats(stats);
-        Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
-        field.setAccessible(true);
-        field.set(fleetCloud, toTerminate);
-
-        // Act
-        fleetCloud.update();
-
-        // Assert - without a warm pool with instance reuse, scale-down falls back to
-        // terminating the instance directly (pre-warm-pool behavior)
-        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
-        verify(autoScalingGroupFleet, never()).removeScaleInProtection(anyString(), any(), any(), anyString(), any());
-    }
-
-    @Test
-    void update_shouldTerminateInstancesInAutoScalingGroupForMaxTotalUsesExhausted() throws IllegalAccessException, NoSuchFieldException {
-        // Arrange
+    void update_shouldDelegateAutoScalingGroupTerminationToFleet() throws IllegalAccessException, NoSuchFieldException {
+        // Arrange - the ASG decides warm-pool reuse vs. direct termination internally, so the cloud
+        // just hands the instances (and their termination reasons) to the fleet.
         final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
         when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
         when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
 
         final FleetStateStats stats = new FleetStateStats(
                 "fleetId", 1, FleetStateStats.State.active(), Collections.singleton("i-0"), Collections.emptyMap());
-        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString()))
-                .thenReturn(stats);
+        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
 
-        EC2FleetCloud fleetCloud = new EC2FleetCloud(
-                "TestCloud",
-                "credId",
-                null,
-                "region",
-                null,
-                "fleetId",
-                null,
-                null,
-                mock(ComputerConnector.class),
-                false,
-                false,
-                0,
-                0,
-                10,
-                0,
-                1,
-                false,
-                false,
-                null,
-                false,
-                null,
-                null,
-                null,
-                false,
-                false,
-                null);
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
+                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
 
-        // Set up instanceIdsToTerminate with MAX_TOTAL_USES_EXHAUSTED
         HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
-        toTerminate.put("i-0", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED);
+        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
         fleetCloud.setStats(stats);
         Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
         field.setAccessible(true);
         field.set(fleetCloud, toTerminate);
 
-        // Under-lock re-verify requires a safely-terminable Computer
-        when(jenkins.getComputer("i-0")).thenReturn(idleComputer);
-
         // Act
         fleetCloud.update();
 
-        // Assert - verify terminateInstances is called for MAX_TOTAL_USES_EXHAUSTED
-        // Instance should be terminated directly so ASG replaces it
-        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"), eq(Collections.singleton("i-0")));
-        verify(autoScalingGroupFleet, never()).removeScaleInProtection(anyString(), any(), any(), anyString(), any());
+        // Assert - the whole map is delegated to the fleet's terminateInstances
+        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"),
+                argThat(m -> m != null && m.containsKey("i-0")));
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -3674,12 +3674,13 @@ class EC2FleetCloudTest {
     }
 
     @Test
-    void update_shouldDelegateAutoScalingGroupTerminationToFleet() throws IllegalAccessException, NoSuchFieldException {
-        // Arrange - the ASG decides warm-pool reuse vs. direct termination internally, so the cloud
-        // just hands the instances (and their termination reasons) to the fleet.
+    void update_shouldScaleDownAutoScalingGroupWithWarmPool() throws IllegalAccessException, NoSuchFieldException {
+        // Arrange - ASG has a warm pool with instance reuse, so the cloud hands the instances (and
+        // their termination reasons) to the fleet's warm-pool scale-down path.
         final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
         when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
         when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
+        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(true);
 
         final FleetStateStats stats = new FleetStateStats(
                 "fleetId", 1, FleetStateStats.State.active(), Collections.singleton("i-0"), Collections.emptyMap());
@@ -3699,9 +3700,41 @@ class EC2FleetCloudTest {
         // Act
         fleetCloud.update();
 
-        // Assert - the whole map is delegated to the fleet's terminateInstances
-        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq("fleetId"),
+        // Assert - the whole map is delegated to the fleet's warm-pool scale-down, not direct termination
+        verify(autoScalingGroupFleet).scaleDownWithWarmPool(anyString(), any(), any(), eq("fleetId"),
                 argThat(m -> m != null && m.containsKey("i-0")));
+        verify(autoScalingGroupFleet, never()).terminateInstances(anyString(), any(), any(), any());
+    }
+
+    @Test
+    void update_shouldTerminateAutoScalingGroupDirectlyWithoutWarmPool() throws IllegalAccessException, NoSuchFieldException {
+        // Arrange - no warm pool with instance reuse, so the cloud terminates the instances directly.
+        final AutoScalingGroupFleet autoScalingGroupFleet = mock(AutoScalingGroupFleet.class);
+        when(EC2Fleets.get(anyString())).thenReturn(autoScalingGroupFleet);
+        when(autoScalingGroupFleet.isAutoScalingGroup()).thenReturn(true);
+        when(autoScalingGroupFleet.hasWarmPoolWithInstanceReuse(anyString(), any(), any(), anyString())).thenReturn(false);
+
+        final FleetStateStats stats = new FleetStateStats(
+                "fleetId", 1, FleetStateStats.State.active(), Collections.singleton("i-0"), Collections.emptyMap());
+        when(autoScalingGroupFleet.getState(anyString(), any(), any(), anyString())).thenReturn(stats);
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                null, "fleetId", null, null, mock(ComputerConnector.class), false, false,
+                0, 0, 10, 0, 1, false, false, null, false, null, null, null, false, false, null);
+
+        HashMap<String, EC2AgentTerminationReason> toTerminate = new HashMap<>();
+        toTerminate.put("i-0", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+        fleetCloud.setStats(stats);
+        Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
+        field.setAccessible(true);
+        field.set(fleetCloud, toTerminate);
+
+        // Act
+        fleetCloud.update();
+
+        // Assert - instances are terminated directly, warm-pool scale-down is not used
+        verify(autoScalingGroupFleet).terminateInstances(anyString(), any(), any(), eq(Collections.singleton("i-0")));
+        verify(autoScalingGroupFleet, never()).scaleDownWithWarmPool(anyString(), any(), any(), anyString(), any());
     }
 
     @Test

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -325,4 +325,86 @@ class AutoScalingGroupFleetTest {
             assertEquals(expectedWeights, result.getInstanceTypeWeights());
         }
     }
+
+    @Test
+    void removeScaleInProtectionShouldCallSetInstanceProtectionWithCorrectParameters() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            final List<String> instanceIds = Arrays.asList("i-123", "i-456");
+
+            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
+
+            final SetInstanceProtectionRequest expectedRequest = SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(ASG_NAME)
+                    .instanceIds(instanceIds)
+                    .protectedFromScaleIn(false)
+                    .build();
+            verify(clientMock, times(1)).setInstanceProtection(expectedRequest);
+        }
+    }
+
+    @Test
+    void removeScaleInProtectionShouldSkipEmptyInstanceIds() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            // Should not call setInstanceProtection when list is empty
+            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyList());
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+
+            // Should not call setInstanceProtection when list is null
+            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+        }
+    }
+
+    @Test
+    void removeScaleInProtectionShouldFilterOutBlankInstanceIds() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            // List with blank entries should filter them out
+            final List<String> instanceIds = Arrays.asList("i-123", "", "i-456", "  ", null);
+
+            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
+
+            final SetInstanceProtectionRequest expectedRequest = SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(ASG_NAME)
+                    .instanceIds(Arrays.asList("i-123", "i-456"))
+                    .protectedFromScaleIn(false)
+                    .build();
+            verify(clientMock, times(1)).setInstanceProtection(expectedRequest);
+        }
+    }
+
+    @Test
+    void removeScaleInProtectionShouldHandleExceptionGracefully() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            when(clientMock.setInstanceProtection(any(SetInstanceProtectionRequest.class)))
+                    .thenThrow(new RuntimeException("AWS error"));
+
+            // Should not throw exception, just log warning
+            assertDoesNotThrow(() -> new AutoScalingGroupFleet().removeScaleInProtection(
+                    CREDS_ID, REGION, ENDPOINT, ASG_NAME, Arrays.asList("i-123")));
+        }
+    }
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -407,4 +407,55 @@ class AutoScalingGroupFleetTest {
                     CREDS_ID, REGION, ENDPOINT, ASG_NAME, Arrays.asList("i-123")));
         }
     }
+
+    @Test
+    void terminateInstancesShouldRemoveProtectionThenTerminate() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            final List<String> instanceIds = Arrays.asList("i-123");
+
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
+
+            // Verify scale-in protection is removed first
+            final SetInstanceProtectionRequest expectedProtectionRequest = SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(ASG_NAME)
+                    .instanceIds("i-123")
+                    .protectedFromScaleIn(false)
+                    .build();
+            verify(clientMock, times(1)).setInstanceProtection(expectedProtectionRequest);
+
+            // Verify instance is terminated
+            final TerminateInstanceInAutoScalingGroupRequest expectedTerminateRequest = TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-123")
+                    .shouldDecrementDesiredCapacity(false)
+                    .build();
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(expectedTerminateRequest);
+        }
+    }
+
+    @Test
+    void terminateInstancesShouldSkipEmptyOrNullInstanceIds() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            // Should not call any API when list is empty
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyList());
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+
+            // Should not call any API when list is null
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+        }
+    }
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.amazon.jenkins.ec2fleet.EC2AgentTerminationReason;
 import com.amazon.jenkins.ec2fleet.FleetStateStats;
 import com.amazon.jenkins.ec2fleet.aws.AWSUtils;
 import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsHelper;
@@ -326,206 +327,137 @@ class AutoScalingGroupFleetTest {
         }
     }
 
+    private AutoScalingClient mockClient(MockedStatic<AutoScalingClient> mockedStatic) {
+        AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+        AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+        mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+        when(builderMock.build()).thenReturn(clientMock);
+        return clientMock;
+    }
+
+    private void stubWarmPoolReuse(AutoScalingClient clientMock, boolean reuseOnScaleIn) {
+        final WarmPoolConfiguration warmPoolConfiguration = WarmPoolConfiguration.builder()
+                .instanceReusePolicy(InstanceReusePolicy.builder().reuseOnScaleIn(reuseOnScaleIn).build())
+                .build();
+        when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
+                .thenReturn(DescribeWarmPoolResponse.builder().warmPoolConfiguration(warmPoolConfiguration).build());
+    }
+
+    private Map<String, EC2AgentTerminationReason> reasons(String instanceId, EC2AgentTerminationReason reason) {
+        final Map<String, EC2AgentTerminationReason> map = new LinkedHashMap<>();
+        map.put(instanceId, reason);
+        return map;
+    }
+
     @Test
-    void removeScaleInProtectionShouldCallSetInstanceProtectionWithCorrectParameters() {
+    void terminateInstances_scaleDownWithWarmPoolReuse_removesProtectionOnly() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+            stubWarmPoolReuse(clientMock, true);
 
-            final List<String> instanceIds = Arrays.asList("i-123", "i-456");
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG));
 
-            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
-
+            // Instance is handed back to the ASG (protection removed) and NOT terminated directly.
             final SetInstanceProtectionRequest expectedRequest = SetInstanceProtectionRequest.builder()
                     .autoScalingGroupName(ASG_NAME)
-                    .instanceIds(instanceIds)
+                    .instanceIds(Collections.singletonList("i-123"))
                     .protectedFromScaleIn(false)
                     .build();
             verify(clientMock, times(1)).setInstanceProtection(expectedRequest);
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
         }
     }
 
     @Test
-    void removeScaleInProtectionShouldSkipEmptyInstanceIds() {
+    void terminateInstances_maxTotalUsesWithWarmPoolReuse_terminatesDirectly() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+            stubWarmPoolReuse(clientMock, true);
 
-            // Should not call setInstanceProtection when list is empty
-            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyList());
-            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED));
 
-            // Should not call setInstanceProtection when list is null
-            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
-            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
-        }
-    }
-
-    @Test
-    void removeScaleInProtectionShouldFilterOutBlankInstanceIds() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            // List with blank entries should filter them out
-            final List<String> instanceIds = Arrays.asList("i-123", "", "i-456", "  ", null);
-
-            new AutoScalingGroupFleet().removeScaleInProtection(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
-
-            final SetInstanceProtectionRequest expectedRequest = SetInstanceProtectionRequest.builder()
-                    .autoScalingGroupName(ASG_NAME)
-                    .instanceIds(Arrays.asList("i-123", "i-456"))
-                    .protectedFromScaleIn(false)
-                    .build();
-            verify(clientMock, times(1)).setInstanceProtection(expectedRequest);
-        }
-    }
-
-    @Test
-    void removeScaleInProtectionShouldHandleExceptionGracefully() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            when(clientMock.setInstanceProtection(any(SetInstanceProtectionRequest.class)))
-                    .thenThrow(new RuntimeException("AWS error"));
-
-            // Should not throw exception, just log warning
-            assertDoesNotThrow(() -> new AutoScalingGroupFleet().removeScaleInProtection(
-                    CREDS_ID, REGION, ENDPOINT, ASG_NAME, Arrays.asList("i-123")));
-        }
-    }
-
-    @Test
-    void terminateInstancesShouldRemoveProtectionThenTerminate() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            final List<String> instanceIds = Arrays.asList("i-123");
-
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instanceIds);
-
-            // Verify scale-in protection is removed first
-            final SetInstanceProtectionRequest expectedProtectionRequest = SetInstanceProtectionRequest.builder()
+            // A worn-out instance must never be reused: drop protection then terminate so the ASG replaces it.
+            verify(clientMock, times(1)).setInstanceProtection(SetInstanceProtectionRequest.builder()
                     .autoScalingGroupName(ASG_NAME)
                     .instanceIds("i-123")
                     .protectedFromScaleIn(false)
-                    .build();
-            verify(clientMock, times(1)).setInstanceProtection(expectedProtectionRequest);
-
-            // Verify instance is terminated
-            final TerminateInstanceInAutoScalingGroupRequest expectedTerminateRequest = TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .build());
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
                     .instanceId("i-123")
                     .shouldDecrementDesiredCapacity(false)
-                    .build();
-            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(expectedTerminateRequest);
+                    .build());
         }
     }
 
     @Test
-    void terminateInstancesShouldSkipEmptyOrNullInstanceIds() {
+    void terminateInstances_withoutWarmPool_terminatesDirectly() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            // Should not call any API when list is empty
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyList());
-            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
-            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
-
-            // Should not call any API when list is null
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
-            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
-            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
-        }
-    }
-
-    @Test
-    void hasWarmPoolWithInstanceReuseShouldReturnTrueWhenReuseOnScaleInEnabled() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            final WarmPoolConfiguration warmPoolConfiguration = WarmPoolConfiguration.builder()
-                    .instanceReusePolicy(InstanceReusePolicy.builder().reuseOnScaleIn(true).build())
-                    .build();
-            when(clientMock.describeWarmPool(DescribeWarmPoolRequest.builder().autoScalingGroupName(ASG_NAME).build()))
-                    .thenReturn(DescribeWarmPoolResponse.builder().warmPoolConfiguration(warmPoolConfiguration).build());
-
-            assertTrue(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
-        }
-    }
-
-    @Test
-    void hasWarmPoolWithInstanceReuseShouldReturnFalseWhenReuseOnScaleInDisabled() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
-            final WarmPoolConfiguration warmPoolConfiguration = WarmPoolConfiguration.builder()
-                    .instanceReusePolicy(InstanceReusePolicy.builder().reuseOnScaleIn(false).build())
-                    .build();
-            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
-                    .thenReturn(DescribeWarmPoolResponse.builder().warmPoolConfiguration(warmPoolConfiguration).build());
-
-            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
-        }
-    }
-
-    @Test
-    void hasWarmPoolWithInstanceReuseShouldReturnFalseWhenNoWarmPoolConfigured() {
-        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
-        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
             when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
                     .thenReturn(DescribeWarmPoolResponse.builder().build());
 
-            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG));
+
+            // No warm pool with reuse -> pre-warm-pool behavior: terminate directly.
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-123")
+                    .shouldDecrementDesiredCapacity(false)
+                    .build());
         }
     }
 
     @Test
-    void hasWarmPoolWithInstanceReuseShouldReturnFalseOnException() {
+    void terminateInstances_warmPoolLookupFails_terminatesDirectly() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
-            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
-            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
-            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
-            when(builderMock.build()).thenReturn(clientMock);
-
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
             when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
                     .thenThrow(new RuntimeException("AWS error"));
 
-            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+            // Should not propagate the failure; falls back to terminating directly.
+            assertDoesNotThrow(() -> new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG)));
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+        }
+    }
+
+    @Test
+    void terminateInstances_skipsBlankIds() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
+                    .thenReturn(DescribeWarmPoolResponse.builder().build());
+
+            final Map<String, EC2AgentTerminationReason> instances = new LinkedHashMap<>();
+            instances.put("  ", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instances);
+
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+        }
+    }
+
+    @Test
+    void terminateInstances_skipsEmptyOrNull() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyMap());
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
+
+            // Warm pool is never even queried when there is nothing to terminate.
+            verify(clientMock, never()).describeWarmPool(any(DescribeWarmPoolRequest.class));
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
         }
     }
 }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -350,112 +350,166 @@ class AutoScalingGroupFleetTest {
     }
 
     @Test
-    void terminateInstances_scaleDownWithWarmPoolReuse_removesProtectionOnly() {
+    void hasWarmPoolWithInstanceReuse_reuseOnScaleInEnabled_returnsTrue() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
             stubWarmPoolReuse(clientMock, true);
 
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
-                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG));
-
-            // Instance is handed back to the ASG (protection removed) and NOT terminated directly.
-            final SetInstanceProtectionRequest expectedRequest = SetInstanceProtectionRequest.builder()
-                    .autoScalingGroupName(ASG_NAME)
-                    .instanceIds(Collections.singletonList("i-123"))
-                    .protectedFromScaleIn(false)
-                    .build();
-            verify(clientMock, times(1)).setInstanceProtection(expectedRequest);
-            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+            assertTrue(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
         }
     }
 
     @Test
-    void terminateInstances_maxTotalUsesWithWarmPoolReuse_terminatesDirectly() {
+    void hasWarmPoolWithInstanceReuse_reuseOnScaleInDisabled_returnsFalse() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
-            stubWarmPoolReuse(clientMock, true);
+            stubWarmPoolReuse(clientMock, false);
 
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
-                    reasons("i-123", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED));
-
-            // A worn-out instance must never be reused: drop protection then terminate so the ASG replaces it.
-            verify(clientMock, times(1)).setInstanceProtection(SetInstanceProtectionRequest.builder()
-                    .autoScalingGroupName(ASG_NAME)
-                    .instanceIds("i-123")
-                    .protectedFromScaleIn(false)
-                    .build());
-            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
-                    .instanceId("i-123")
-                    .shouldDecrementDesiredCapacity(false)
-                    .build());
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
         }
     }
 
     @Test
-    void terminateInstances_withoutWarmPool_terminatesDirectly() {
+    void hasWarmPoolWithInstanceReuse_noWarmPool_returnsFalse() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
             when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
                     .thenReturn(DescribeWarmPoolResponse.builder().build());
 
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
-                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG));
-
-            // No warm pool with reuse -> pre-warm-pool behavior: terminate directly.
-            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
-                    .instanceId("i-123")
-                    .shouldDecrementDesiredCapacity(false)
-                    .build());
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
         }
     }
 
     @Test
-    void terminateInstances_warmPoolLookupFails_terminatesDirectly() {
+    void hasWarmPoolWithInstanceReuse_lookupFails_returnsFalse() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
             when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
                     .thenThrow(new RuntimeException("AWS error"));
 
-            // Should not propagate the failure; falls back to terminating directly.
-            assertDoesNotThrow(() -> new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
-                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG)));
-            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
         }
     }
 
     @Test
-    void terminateInstances_skipsBlankIds() {
+    void terminateInstances_terminatesEachDirectly() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
-            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
-                    .thenReturn(DescribeWarmPoolResponse.builder().build());
 
-            final Map<String, EC2AgentTerminationReason> instances = new LinkedHashMap<>();
-            instances.put("  ", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, Arrays.asList("i-123", "i-456"));
 
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instances);
+            // Direct termination, no scale-in protection changes and no warm pool lookup.
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-123").shouldDecrementDesiredCapacity(false).build());
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-456").shouldDecrementDesiredCapacity(false).build());
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            verify(clientMock, never()).describeWarmPool(any(DescribeWarmPoolRequest.class));
+        }
+    }
 
+    @Test
+    void terminateInstances_blankId_throws() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            mockClient(mockedStatic);
+
+            assertThrows(IllegalArgumentException.class, () ->
+                    new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, Collections.singletonList("  ")));
+        }
+    }
+
+    @Test
+    void scaleDownWithWarmPool_scaleDownReason_removesProtectionOnly() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG));
+
+            // Instance is handed back to the ASG (protection removed) and NOT terminated directly.
+            verify(clientMock, times(1)).setInstanceProtection(SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(ASG_NAME)
+                    .instanceIds(Collections.singletonList("i-123"))
+                    .protectedFromScaleIn(false)
+                    .build());
             verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+        }
+    }
+
+    @Test
+    void scaleDownWithWarmPool_maxTotalUses_terminatesDirectly() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME,
+                    reasons("i-123", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED));
+
+            // A worn-out instance must never be reused: terminate directly, don't remove protection.
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-123")
+                    .shouldDecrementDesiredCapacity(false)
+                    .build());
             verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
         }
     }
 
     @Test
-    void terminateInstances_skipsEmptyOrNull() {
+    void scaleDownWithWarmPool_mixedReasons_splitsProtectionAndTermination() {
         mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
         try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
             final AutoScalingClient clientMock = mockClient(mockedStatic);
 
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyMap());
-            new AutoScalingGroupFleet().terminateInstances(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
+            final Map<String, EC2AgentTerminationReason> instances = new LinkedHashMap<>();
+            instances.put("i-scale", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+            instances.put("i-worn", EC2AgentTerminationReason.MAX_TOTAL_USES_EXHAUSTED);
 
-            // Warm pool is never even queried when there is nothing to terminate.
-            verify(clientMock, never()).describeWarmPool(any(DescribeWarmPoolRequest.class));
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instances);
+
+            verify(clientMock, times(1)).setInstanceProtection(SetInstanceProtectionRequest.builder()
+                    .autoScalingGroupName(ASG_NAME)
+                    .instanceIds(Collections.singletonList("i-scale"))
+                    .protectedFromScaleIn(false)
+                    .build());
+            verify(clientMock, times(1)).terminateInstanceInAutoScalingGroup(TerminateInstanceInAutoScalingGroupRequest.builder()
+                    .instanceId("i-worn")
+                    .shouldDecrementDesiredCapacity(false)
+                    .build());
+        }
+    }
+
+    @Test
+    void scaleDownWithWarmPool_skipsBlankIds() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+
+            final Map<String, EC2AgentTerminationReason> instances = new LinkedHashMap<>();
+            instances.put("  ", EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME, instances);
+
+            verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
+            verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
+        }
+    }
+
+    @Test
+    void scaleDownWithWarmPool_skipsEmptyOrNull() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            final AutoScalingClient clientMock = mockClient(mockedStatic);
+
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME, Collections.emptyMap());
+            new AutoScalingGroupFleet().scaleDownWithWarmPool(CREDS_ID, REGION, ENDPOINT, ASG_NAME, null);
+
             verify(clientMock, never()).setInstanceProtection(any(SetInstanceProtectionRequest.class));
             verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
         }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/fleet/AutoScalingGroupFleetTest.java
@@ -458,4 +458,74 @@ class AutoScalingGroupFleetTest {
             verify(clientMock, never()).terminateInstanceInAutoScalingGroup(any(TerminateInstanceInAutoScalingGroupRequest.class));
         }
     }
+
+    @Test
+    void hasWarmPoolWithInstanceReuseShouldReturnTrueWhenReuseOnScaleInEnabled() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            final WarmPoolConfiguration warmPoolConfiguration = WarmPoolConfiguration.builder()
+                    .instanceReusePolicy(InstanceReusePolicy.builder().reuseOnScaleIn(true).build())
+                    .build();
+            when(clientMock.describeWarmPool(DescribeWarmPoolRequest.builder().autoScalingGroupName(ASG_NAME).build()))
+                    .thenReturn(DescribeWarmPoolResponse.builder().warmPoolConfiguration(warmPoolConfiguration).build());
+
+            assertTrue(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+        }
+    }
+
+    @Test
+    void hasWarmPoolWithInstanceReuseShouldReturnFalseWhenReuseOnScaleInDisabled() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            final WarmPoolConfiguration warmPoolConfiguration = WarmPoolConfiguration.builder()
+                    .instanceReusePolicy(InstanceReusePolicy.builder().reuseOnScaleIn(false).build())
+                    .build();
+            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
+                    .thenReturn(DescribeWarmPoolResponse.builder().warmPoolConfiguration(warmPoolConfiguration).build());
+
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+        }
+    }
+
+    @Test
+    void hasWarmPoolWithInstanceReuseShouldReturnFalseWhenNoWarmPoolConfigured() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
+                    .thenReturn(DescribeWarmPoolResponse.builder().build());
+
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+        }
+    }
+
+    @Test
+    void hasWarmPoolWithInstanceReuseShouldReturnFalseOnException() {
+        mockedAWSCredentialsHelper.when(() -> AWSCredentialsHelper.getCredentials(CREDS_ID, jenkins)).thenReturn(amazonWebServicesCredentials);
+        try (MockedStatic<AutoScalingClient> mockedStatic = mockStatic(AutoScalingClient.class)) {
+            AutoScalingClientBuilder builderMock = Mockito.mock(AutoScalingClientBuilder.class, Mockito.RETURNS_SELF);
+            AutoScalingClient clientMock = Mockito.mock(AutoScalingClient.class);
+            mockedStatic.when(AutoScalingClient::builder).thenReturn(builderMock);
+            when(builderMock.build()).thenReturn(clientMock);
+
+            when(clientMock.describeWarmPool(any(DescribeWarmPoolRequest.class)))
+                    .thenThrow(new RuntimeException("AWS error"));
+
+            assertFalse(new AutoScalingGroupFleet().hasWarmPoolWithInstanceReuse(CREDS_ID, REGION, ENDPOINT, ASG_NAME));
+        }
+    }
 }


### PR DESCRIPTION
The idea behind this PR is to allow ASG to use warm pool, for faster builds - it's faster to get stopped instance from warm pool, than spin up it from image, and stopped instance will have caches/checked out code from last build.

Implementation details:
Instead of terminating instance - plugin removes scale-in protection from the instance it wants to terminate and allows ASG to handle instance termination - AGS will move this instance back to warm pool if there is one configured.

Related to #352 

### Testing done

Tested on live jenkins instance, and corrected automated tests.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
