### PR TITLE
Fix race that terminated busy agents

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -543,11 +543,8 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Jenkins j = Jenkins.get();
         final Map<String, EC2AgentTerminationReason> filteredInstanceIdsToTerminate = instanceIdsToTerminate.entrySet()
                 .stream()
-                .filter(e -> {
-                    final Computer c = j.getComputer(e.getKey());
-                    return c == null || c.isIdle();
-                })
-                .collect(Collectors.toMap(Map.Entry::getKey,Map.Entry::getValue));
+                .filter(e -> isSafeToTerminate(j.getComputer(e.getKey())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         final Set<String> filteredOutNonIdleIds = Sets.difference(instanceIdsToTerminate.keySet(), filteredInstanceIdsToTerminate.keySet());
         if (filteredOutNonIdleIds.size() > 0) {
@@ -555,6 +552,22 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         }
 
         return filteredInstanceIdsToTerminate;
+    }
+
+    /**
+     * Returns whether the given {@link Computer} is safe to terminate, i.e. not running any builds and
+     * not available for the queue to dispatch new work to. A null computer is treated as safe, since
+     * the node is already gone from Jenkins.
+     * <p>
+     * Callers scheduling a termination are expected to first mark the computer as not accepting tasks
+     * (see {@link EC2RetentionStrategy} and {@link EC2FleetNodeComputer#doDoDelete()}), so that the
+     * queue cannot bind new work to it between the check here and the call to terminate on EC2.
+     */
+    private static boolean isSafeToTerminate(final Computer c) {
+        if (c == null) return true;
+        if (c.countBusy() > 0) return false;
+        if (c.isAcceptingTasks()) return false;
+        return c.isIdle();
     }
 
     public boolean removePlannedNodeScheduledFutures(final int numToRemove) {
@@ -579,6 +592,34 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Jenkins jenkins = Jenkins.get();
         final Ec2Client ec2 = Registry.getEc2Api().connect(getAwsCredentialsId(), region, endpoint);
 
+        if (currentInstanceIdsToTerminate.size() > 0) {
+            // Re-verify each candidate atomically with removeNode under Queue.withLock; drop any that became busy (issue#436).
+            // AWS terminateInstances stays outside the lock — after removeNode the dispatcher can't assign tasks to the node.
+            // Must run before targetCapacity is computed so dropped entries don't shrink the fleet.
+            Queue.withLock(new Runnable() {
+                @Override
+                public void run() {
+                    final Iterator<Map.Entry<String, EC2AgentTerminationReason>> it = currentInstanceIdsToTerminate.entrySet().iterator();
+                    while (it.hasNext()) {
+                        final Map.Entry<String, EC2AgentTerminationReason> entry = it.next();
+                        final String instanceId = entry.getKey();
+                        if (!isSafeToTerminate(jenkins.getComputer(instanceId))) {
+                            it.remove();
+                            continue;
+                        }
+                        final Node node = jenkins.getNode(instanceId);
+                        if (node != null) {
+                            try {
+                                jenkins.removeNode(node);
+                            } catch (IOException e) {
+                                warning("Failed to remove node '%s' from Jenkins before termination.", instanceId);
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
         // Ensure target capacity is not negative (covers capacity updates from outside the plugin)
         final int targetCapacity = Math.max(minSize,
                 Math.min(maxSize, currentState.getNumDesired() - currentInstanceIdsToTerminate.size() + currentToAdd));
@@ -595,30 +636,10 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final FleetStateStats updatedState = new FleetStateStats(currentState, targetCapacity);
 
         if (currentInstanceIdsToTerminate.size() > 0) {
-            // internally removeNode lock on queue to correctly update node list
-            // we do big block for all removal to avoid delay on lock waiting
-            // for each node
-            Queue.withLock(new Runnable() {
-                @Override
-                public void run() {
-                    info("Removing Jenkins nodes before terminating corresponding EC2 instances");
-                    for (final String instanceId : currentInstanceIdsToTerminate.keySet()) {
-                        final Node node = jenkins.getNode(instanceId);
-                        if (node != null) {
-                            try {
-                                jenkins.removeNode(node);
-                            } catch (IOException e) {
-                                warning("Failed to remove node '%s' from Jenkins before termination.", instanceId);
-                            }
-                        }
-                    }
-                }
-            });
-            if(EC2Fleets.get(fleet).isAutoScalingGroup()){
+            if (EC2Fleets.get(fleet).isAutoScalingGroup()) {
                 fine("Terminating instances in AutoScalingGroup: %s", currentInstanceIdsToTerminate.keySet());
                 ((AutoScalingGroupFleet) EC2Fleets.get(fleet)).terminateInstances(awsCredentialsId, region, endpoint, currentInstanceIdsToTerminate.keySet());
-            }
-            else {
+            } else {
                 fine("Terminating instances: %s", currentInstanceIdsToTerminate.keySet());
                 Registry.getEc2Api().terminateInstances(ec2, currentInstanceIdsToTerminate.keySet());
             }

--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetNodeComputer.java
@@ -77,6 +77,9 @@ public class EC2FleetNodeComputer extends SlaveComputer {
             final String instanceId = node.getInstanceId();
             final AbstractEC2FleetCloud cloud = node.getCloud();
             if (cloud != null && StringUtils.isNotBlank(instanceId)) {
+                // Suspend the computer before scheduling so the queue cannot dispatch new work to it
+                // between now and when the cloud's next update cycle terminates the instance on EC2.
+                setAcceptingTasks(false);
                 cloud.scheduleToTerminate(instanceId, false, EC2AgentTerminationReason.AGENT_DELETED);
                 // Persist a flag here as the cloud objects can be re-created on user-initiated changes, hence, losing track of instance ids scheduled to terminate.
                 this.isMarkedForDeletion = true;

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -1317,6 +1317,112 @@ class EC2FleetCloudTest {
         assertEquals(new HashSet<>(Arrays.asList("i-2")), fleetCloud.getInstanceIdsToTerminate().keySet());
     }
 
+    // issue#436: accepting-tasks computer must not be terminated, even if isIdle() is true.
+    @Test
+    void update_shouldNotTerminate_whenComputerIsAcceptingTasks() {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.describeInstances(any(Ec2Client.class), any(Set.class))).thenReturn(new HashMap<String, Instance>() {{
+                put("i-1", Instance.builder().publicIpAddress("p-ip").instanceId("i-1").build());
+        }});
+        Mockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
+                        Collections.singleton("i-1"), Collections.emptyMap()));
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                "", "fleetId", "", null, Mockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 2, 0, 1, false,
+                false, "-1", false,
+                0, 0, 10, false, false, noScaling);
+
+        final EC2FleetNodeComputer acceptingComputer = mock(EC2FleetNodeComputer.class);
+        when(acceptingComputer.isIdle()).thenReturn(true);
+        when(acceptingComputer.countBusy()).thenReturn(0);
+        when(acceptingComputer.isAcceptingTasks()).thenReturn(true);
+        when(jenkins.getComputer("i-1")).thenReturn(acceptingComputer);
+
+        fleetCloud.scheduleToTerminate("i-1", false, EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+        // when
+        fleetCloud.update();
+
+        // then - no AWS terminate fired; instance stays in the map for next cycle
+        verify(ec2Api, never()).terminateInstances(any(Ec2Client.class), any(Set.class));
+        assertEquals(Collections.singleton("i-1"), fleetCloud.getInstanceIdsToTerminate().keySet());
+    }
+
+    // issue#436: defense-in-depth against a partial mock where isIdle() disagrees with countBusy().
+    @Test
+    void update_shouldNotTerminate_whenCountBusyGreaterThanZero() {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.describeInstances(any(Ec2Client.class), any(Set.class))).thenReturn(new HashMap<String, Instance>() {{
+                put("i-1", Instance.builder().publicIpAddress("p-ip").instanceId("i-1").build());
+        }});
+        Mockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
+                        Collections.singleton("i-1"), Collections.emptyMap()));
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                "", "fleetId", "", null, Mockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 2, 0, 1, false,
+                false, "-1", false,
+                0, 0, 10, false, false, noScaling);
+
+        final EC2FleetNodeComputer busyByCount = mock(EC2FleetNodeComputer.class);
+        when(busyByCount.isIdle()).thenReturn(true);
+        when(busyByCount.countBusy()).thenReturn(1);
+        when(busyByCount.isAcceptingTasks()).thenReturn(false);
+        when(jenkins.getComputer("i-1")).thenReturn(busyByCount);
+
+        fleetCloud.scheduleToTerminate("i-1", false, EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+        // when
+        fleetCloud.update();
+
+        // then
+        verify(ec2Api, never()).terminateInstances(any(Ec2Client.class), any(Set.class));
+        assertEquals(Collections.singleton("i-1"), fleetCloud.getInstanceIdsToTerminate().keySet());
+    }
+
+    // issue#436: idle at first-pass filter, busy by the under-lock re-verify — must be dropped, not terminated.
+    @Test
+    void update_shouldDropInstance_whenBecomesBusyUnderLock() {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.describeInstances(any(Ec2Client.class), any(Set.class))).thenReturn(new HashMap<String, Instance>() {{
+                put("i-1", Instance.builder().publicIpAddress("p-ip").instanceId("i-1").build());
+        }});
+        Mockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new FleetStateStats("fleetId", 1, FleetStateStats.State.active(),
+                        Collections.singleton("i-1"), Collections.emptyMap()));
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud("TestCloud", "credId", null, "region",
+                "", "fleetId", "", null, Mockito.mock(ComputerConnector.class), false,
+                false, 0, 0, 2, 0, 1, false,
+                false, "-1", false,
+                0, 0, 10, false, false, noScaling);
+
+        final EC2FleetNodeComputer racingComputer = mock(EC2FleetNodeComputer.class);
+        when(racingComputer.isIdle()).thenReturn(true);
+        when(racingComputer.isAcceptingTasks()).thenReturn(false);
+        // Idle at first-pass filter, then a task lands before the under-lock re-verify.
+        when(racingComputer.countBusy()).thenReturn(0).thenReturn(1);
+        when(jenkins.getComputer("i-1")).thenReturn(racingComputer);
+
+        fleetCloud.scheduleToTerminate("i-1", false, EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+        // when
+        fleetCloud.update();
+
+        // then - dropped by the under-lock re-verify
+        verify(ec2Api, never()).terminateInstances(any(Ec2Client.class), any(Set.class));
+        assertEquals(Collections.singleton("i-1"), fleetCloud.getInstanceIdsToTerminate().keySet());
+        // target capacity must be computed from the post-drop size; with nothing terminated and numDesired==1,
+        // modify() should not be called (or if called, not below numDesired).
+        verify(ec2Fleet, never()).modify(anyString(), anyString(), anyString(), eq("fleetId"), eq(0), anyInt(), anyInt());
+    }
+
     @Test
     void update_shouldUpdateStateWithMinSpare() throws IOException {
         // given
@@ -2177,6 +2283,9 @@ class EC2FleetCloudTest {
         field.setAccessible(true);
         field.set(fleetCloud, toTerminate);
 
+        // Under-lock re-verify requires a safely-terminable Computer
+        when(jenkins.getComputer("i-0")).thenReturn(idleComputer);
+
         // Act
         fleetCloud.update();
 
@@ -2209,6 +2318,9 @@ class EC2FleetCloudTest {
         Field field = EC2FleetCloud.class.getDeclaredField("instanceIdsToTerminate");
         field.setAccessible(true);
         field.set(fleetCloud, toTerminate);
+
+        // Under-lock re-verify requires a safely-terminable Computer
+        when(jenkins.getComputer("i-0")).thenReturn(idleComputer);
 
         // Act
         fleetCloud.update();


### PR DESCRIPTION
The pre-termination idle check ran outside Queue.withLock, so the dispatcher could bind a task to a node between the check and the AWS terminateInstances call, killing a running build.

- Suspend the computer (setAcceptingTasks(false)) in EC2FleetNodeComputer#doDoDelete before scheduling termination so the queue stops dispatching to it immediately.
- In EC2FleetCloud#update, re-verify each candidate under Queue.withLock via isSafeToTerminate (checks countBusy, isAcceptingTasks, isIdle) and drop any that became busy; run this before targetCapacity is computed so dropped entries don't shrink the fleet.
- AWS terminateInstances stays outside the lock — safe because removeNode already detached the node from the queue.

Related to #436 

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I have not completed testing on a Jenkins instance yet, just the new automated testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
