### PR TITLE
Fix: busy agent terminated during scale-in when its Computer momentarily resolves to null

### DIFF
--- a/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
+++ b/src/main/java/com/amazon/jenkins/ec2fleet/EC2FleetCloud.java
@@ -561,7 +561,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
         final Jenkins j = Jenkins.get();
         final Map<String, EC2AgentTerminationReason> filteredInstanceIdsToTerminate =
                 instanceIdsToTerminate.entrySet().stream()
-                        .filter(e -> isSafeToTerminate(j.getComputer(e.getKey())))
+                        .filter(e -> isSafeToTerminate(j, e.getKey()))
                         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
         final Set<String> filteredOutNonIdleIds =
@@ -576,16 +576,29 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
     }
 
     /**
-     * Returns whether the given {@link Computer} is safe to terminate, i.e. not running any builds and
-     * not available for the queue to dispatch new work to. A null computer is treated as safe, since
-     * the node is already gone from Jenkins.
+     * Returns whether the instance backing {@code instanceId} is safe to terminate, i.e. it is not
+     * running any builds and is not available for the queue to dispatch new work to.
+     * <p>
+     * When the {@link Computer} cannot be resolved, the outcome depends on whether a {@link Node}
+     * still exists: if neither the node nor the computer is present the instance is a genuine orphan
+     * (already gone from Jenkins) and is safe to terminate; but if the node still exists while the
+     * computer is only momentarily unresolved (e.g. during (re)connection or a fleet resync),
+     * termination is deferred so that an agent which may be running a build is never swept into a
+     * scale-in. Previously a {@code null} computer was unconditionally treated as safe, which allowed
+     * a busy agent to be terminated whenever its computer briefly failed to resolve.
      * <p>
      * Callers scheduling a termination are expected to first mark the computer as not accepting tasks
      * (see {@link EC2RetentionStrategy} and {@link EC2FleetNodeComputer#doDoDelete()}), so that the
      * queue cannot bind new work to it between the check here and the call to terminate on EC2.
      */
-    private static boolean isSafeToTerminate(final Computer c) {
-        if (c == null) return true;
+    private static boolean isSafeToTerminate(final Jenkins j, final String instanceId) {
+        final Computer c = j.getComputer(instanceId);
+        if (c == null) {
+            // No computer: only a genuine orphan (no Node either) is safe to reap. A node that still
+            // exists without a resolved computer is transient -> defer rather than risk terminating a
+            // busy agent whose computer momentarily failed to resolve.
+            return j.getNode(instanceId) == null;
+        }
         if (c.countBusy() > 0) return false;
         if (c.isAcceptingTasks()) return false;
         return c.isIdle();
@@ -629,7 +642,7 @@ public class EC2FleetCloud extends AbstractEC2FleetCloud {
                     while (it.hasNext()) {
                         final Map.Entry<String, EC2AgentTerminationReason> entry = it.next();
                         final String instanceId = entry.getKey();
-                        if (!isSafeToTerminate(jenkins.getComputer(instanceId))) {
+                        if (!isSafeToTerminate(jenkins, instanceId)) {
                             it.remove();
                             continue;
                         }

--- a/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
+++ b/src/test/java/com/amazon/jenkins/ec2fleet/EC2FleetCloudTest.java
@@ -2297,6 +2297,76 @@ class EC2FleetCloudTest {
                 fleetCloud.getInstanceIdsToTerminate().keySet());
     }
 
+    // A computer that momentarily fails to resolve (null) while its Node still exists must NOT be
+    // terminated -- only a genuine orphan (no Node AND no Computer) is safe to reap. Guards against a busy
+    // agent being swept into a scale-in during a (re)connection/resync window when getComputer() is null.
+    @Test
+    void update_shouldNotTerminate_whenComputerNullButNodeStillExists() {
+        // given
+        when(ec2Api.connect(any(String.class), any(String.class), anyString())).thenReturn(amazonEC2);
+        when(ec2Api.describeInstances(any(Ec2Client.class), any(Set.class)))
+                .thenReturn(new HashMap<String, Instance>() {
+                    {
+                        put(
+                                "i-1",
+                                Instance.builder()
+                                        .publicIpAddress("p-ip")
+                                        .instanceId("i-1")
+                                        .build());
+                    }
+                });
+        Mockito.when(ec2Fleet.getState(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(new FleetStateStats(
+                        "fleetId",
+                        1,
+                        FleetStateStats.State.active(),
+                        Collections.singleton("i-1"),
+                        Collections.emptyMap()));
+
+        EC2FleetCloud fleetCloud = new EC2FleetCloud(
+                "TestCloud",
+                "credId",
+                null,
+                "region",
+                "",
+                "fleetId",
+                "",
+                null,
+                Mockito.mock(ComputerConnector.class),
+                false,
+                false,
+                0,
+                0,
+                2,
+                0,
+                1,
+                false,
+                false,
+                "-1",
+                false,
+                0,
+                0,
+                10,
+                false,
+                false,
+                noScaling);
+
+        // Computer momentarily unresolved (null), but the Node still exists (e.g. mid-reconnect / resync).
+        when(jenkins.getComputer("i-1")).thenReturn(null);
+        when(jenkins.getNode("i-1")).thenReturn(Mockito.mock(hudson.model.Node.class));
+
+        fleetCloud.scheduleToTerminate("i-1", false, EC2AgentTerminationReason.IDLE_FOR_TOO_LONG);
+
+        // when
+        fleetCloud.update();
+
+        // then - not terminated; kept for a future cycle once the computer resolves
+        verify(ec2Api, never()).terminateInstances(any(Ec2Client.class), any(Set.class));
+        assertEquals(
+                Collections.singleton("i-1"),
+                fleetCloud.getInstanceIdsToTerminate().keySet());
+    }
+
     // issue#436: defense-in-depth against a partial mock where isIdle() disagrees with countBusy().
     @Test
     void update_shouldNotTerminate_whenCountBusyGreaterThanZero() {


### PR DESCRIPTION
Fixes #576.

## Problem

During routine scale-in the plugin can terminate an instance that is **actively running a build**. `isSafeToTerminate()` treats a `null` `Computer` as unconditionally safe:

```java
private static boolean isSafeToTerminate(final Computer c) {
    if (c == null) return true;          // <-- busy check never reached
    if (c.countBusy() > 0) return false;
    ...
}
```

During the plugin's own node-cleanup / fleet-resync windows, `getComputer(instanceId)` can momentarily return `null` for an instance whose agent is still running a build (observed alongside `the Jenkins node for instance '...' was null` / `Cloud is null for computer unknown fleet ...`). The `countBusy()` guard is bypassed and the busy node is swept into the scale-in; the build dies with `ChannelClosedException` / `Agent was removed`. The `#436` `Queue.withLock` re-verify doesn't help here because it calls the same `isSafeToTerminate`, which still returns `true` for a null computer.

## Fix

Resolve the `Node` as well. An instance is safe to reap only when **both** the `Node` and the `Computer` are absent (a genuine orphan). When the `Node` still exists but the `Computer` is only transiently unresolved, termination is deferred to a later cycle instead of killing a possibly-busy agent.

## Compatibility

Existing orphan-reaping behavior is unchanged: when there is neither a `Node` nor a `Computer` (e.g. `AGENT_DELETED`), the instance is still terminated. Verified by the existing `update_shouldTerminateIdleOrNullInstancesOnly` test, which continues to pass.

## Tests

- Added `update_shouldNotTerminate_whenComputerNullButNodeStillExists`: a null computer with a still-present node is not terminated and stays queued.
- Full suite green: `Tests run: 95, Failures: 0, Errors: 0` in `EC2FleetCloudTest` (JDK 17).